### PR TITLE
use inline env instead of configmap

### DIFF
--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: route-to-httpproxy-config
-  namespace: route-to-contour-httpproxy-system
-data:
-  ROUTER_CONTOUR_RATIO: 1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,9 +70,9 @@ spec:
         - /manager
         args:
         - --leader-elect
-        envFrom:
-          - configMapRef:
-              name: route-to-httpproxy-config
+        env:
+          - name: ROUTER_CONTOUR_RATIO
+            value: "1"
         image: ghcr.io/snapp-incubator/route-to-contour-httpproxy:1.2.6
         name: manager
         livenessProbe:


### PR DESCRIPTION
This MR removes the need for an extra `ConfigMap` object and prefers using inline env for the controller-manager container.