### PR TITLE
Add test to controller

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,9 @@
 name: Main
 
 on:
-  push
+  push:
+  pull_request:
+    branches: [ main ]
 
 jobs:
   lint:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,12 +17,20 @@ jobs:
         with:
           version: latest
           args: --timeout 5m
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: run tests using make
+        run: make test
   docker:
     name: docker
     if: startsWith(github.event.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs:
       - lint
+      - test
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.26.1
+ENVTEST_K8S_VERSION = 1.25.0
 
 ROUTER_CONTOUR_RATIO ?= 1
 
@@ -79,8 +79,6 @@ docker-build: test ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
-
-docker: docker-build docker-push
 
 # PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controlle
 which provide a reconcile function responsible for synchronizing resources until the desired state is reached on the
 cluster.
 
+### Running Tests
+
+1. Make sure the sample config exists first.
+
+```shell
+ls -l hack/config.yaml
+```
+
+2. Run the tests defined inside Makefile. These tests run on envtest, so you don't need to connect to a working cluster.
+
+```shell
+make test
+```
+
 ### Test It Out
 
 1. Run the controller (this will run in the foreground, so switch to a new terminal if you want to leave it running):

--- a/config/external-crd/projectcontour.io_httpproxies.yaml
+++ b/config/external-crd/projectcontour.io_httpproxies.yaml
@@ -1,0 +1,7844 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: contourconfigurations.projectcontour.io
+spec:
+  preserveUnknownFields: false
+  group: projectcontour.io
+  names:
+    kind: ContourConfiguration
+    listKind: ContourConfigurationList
+    plural: contourconfigurations
+    shortNames:
+      - contourconfig
+    singular: contourconfiguration
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ContourConfiguration is the schema for a Contour instance.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ContourConfigurationSpec represents a configuration of a
+                Contour controller. It contains most of all the options that can be
+                customized, the other remaining options being command line flags.
+              properties:
+                debug:
+                  description: Debug contains parameters to enable debug logging and
+                    debug interfaces inside Contour.
+                  properties:
+                    address:
+                      description: "Defines the Contour debug address interface. \n
+                      Contour's default is \"127.0.0.1\"."
+                      type: string
+                    port:
+                      description: "Defines the Contour debug address port. \n Contour's
+                      default is 6060."
+                      type: integer
+                  type: object
+                enableExternalNameService:
+                  description: "EnableExternalNameService allows processing of ExternalNameServices
+                  \n Contour's default is false for security reasons."
+                  type: boolean
+                envoy:
+                  description: Envoy contains parameters for Envoy as well as how to
+                    optionally configure a managed Envoy fleet.
+                  properties:
+                    clientCertificate:
+                      description: ClientCertificate defines the namespace/name of the
+                        Kubernetes secret containing the client certificate and private
+                        key to be used when establishing TLS connection to upstream
+                        cluster.
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - namespace
+                      type: object
+                    cluster:
+                      description: Cluster holds various configurable Envoy cluster
+                        values that can be set in the config file.
+                      properties:
+                        dnsLookupFamily:
+                          description: "DNSLookupFamily defines how external names are
+                          looked up When configured as V4, the DNS resolver will only
+                          perform a lookup for addresses in the IPv4 family. If V6
+                          is configured, the DNS resolver will only perform a lookup
+                          for addresses in the IPv6 family. If AUTO is configured,
+                          the DNS resolver will first perform a lookup for addresses
+                          in the IPv6 family and fallback to a lookup for addresses
+                          in the IPv4 family. If ALL is specified, the DNS resolver
+                          will perform a lookup for both IPv4 and IPv6 families, and
+                          return all resolved addresses. When this is used, Happy
+                          Eyeballs will be enabled for upstream connections. Refer
+                          to Happy Eyeballs Support for more information. Note: This
+                          only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                          for more information. \n Values: `auto` (default), `v4`,
+                          `v6`, `all`. \n Other values will produce an error."
+                          type: string
+                        maxRequestsPerConnection:
+                          description: Defines the maximum requests for upstream connections.
+                            If not specified, there is no limit. see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions
+                            for more information.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        per-connection-buffer-limit-bytes:
+                          description: Defines the soft limit on size of the cluster’s
+                            new connection read and write buffers in bytes. If unspecified,
+                            an implementation defined default is applied (1MiB). see
+                            https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-per-connection-buffer-limit-bytes
+                            for more information.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                      type: object
+                    defaultHTTPVersions:
+                      description: "DefaultHTTPVersions defines the default set of HTTPS
+                      versions the proxy should accept. HTTP versions are strings
+                      of the form \"HTTP/xx\". Supported versions are \"HTTP/1.1\"
+                      and \"HTTP/2\". \n Values: `HTTP/1.1`, `HTTP/2` (default: both).
+                      \n Other values will produce an error."
+                      items:
+                        description: HTTPVersionType is the name of a supported HTTP
+                          version.
+                        type: string
+                      type: array
+                    health:
+                      description: "Health defines the endpoint Envoy uses to serve
+                      health checks. \n Contour's default is { address: \"0.0.0.0\",
+                      port: 8002 }."
+                      properties:
+                        address:
+                          description: Defines the health address interface.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Defines the health port.
+                          type: integer
+                      type: object
+                    http:
+                      description: "Defines the HTTP Listener for Envoy. \n Contour's
+                      default is { address: \"0.0.0.0\", port: 8080, accessLog: \"/dev/stdout\"
+                      }."
+                      properties:
+                        accessLog:
+                          description: AccessLog defines where Envoy logs are outputted
+                            for this listener.
+                          type: string
+                        address:
+                          description: Defines an Envoy Listener Address.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Defines an Envoy listener Port.
+                          type: integer
+                      type: object
+                    https:
+                      description: "Defines the HTTPS Listener for Envoy. \n Contour's
+                      default is { address: \"0.0.0.0\", port: 8443, accessLog: \"/dev/stdout\"
+                      }."
+                      properties:
+                        accessLog:
+                          description: AccessLog defines where Envoy logs are outputted
+                            for this listener.
+                          type: string
+                        address:
+                          description: Defines an Envoy Listener Address.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Defines an Envoy listener Port.
+                          type: integer
+                      type: object
+                    listener:
+                      description: Listener hold various configurable Envoy listener
+                        values.
+                      properties:
+                        connectionBalancer:
+                          description: "ConnectionBalancer. If the value is exact, the
+                          listener will use the exact connection balancer See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
+                          for more information. \n Values: (empty string): use the
+                          default ConnectionBalancer, `exact`: use the Exact ConnectionBalancer.
+                          \n Other values will produce an error."
+                          type: string
+                        disableAllowChunkedLength:
+                          description: "DisableAllowChunkedLength disables the RFC-compliant
+                          Envoy behavior to strip the \"Content-Length\" header if
+                          \"Transfer-Encoding: chunked\" is also set. This is an emergency
+                          off-switch to revert back to Envoy's default behavior in
+                          case of failures. Please file an issue if failures are encountered.
+                          See: https://github.com/projectcontour/contour/issues/3221
+                          \n Contour's default is false."
+                          type: boolean
+                        disableMergeSlashes:
+                          description: "DisableMergeSlashes disables Envoy's non-standard
+                          merge_slashes path transformation option which strips duplicate
+                          slashes from request URL paths. \n Contour's default is
+                          false."
+                          type: boolean
+                        maxRequestsPerConnection:
+                          description: Defines the maximum requests for downstream connections.
+                            If not specified, there is no limit. see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions
+                            for more information.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        per-connection-buffer-limit-bytes:
+                          description: Defines the soft limit on size of the listener’s
+                            new connection read and write buffers in bytes. If unspecified,
+                            an implementation defined default is applied (1MiB). see
+                            https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto#envoy-v3-api-field-config-listener-v3-listener-per-connection-buffer-limit-bytes
+                            for more information.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        serverHeaderTransformation:
+                          description: "Defines the action to be applied to the Server
+                          header on the response path. When configured as overwrite,
+                          overwrites any Server header with \"envoy\". When configured
+                          as append_if_absent, if a Server header is present, pass
+                          it through, otherwise set it to \"envoy\". When configured
+                          as pass_through, pass through the value of the Server header,
+                          and do not append a header if none is present. \n Values:
+                          `overwrite` (default), `append_if_absent`, `pass_through`
+                          \n Other values will produce an error. Contour's default
+                          is overwrite."
+                          type: string
+                        tls:
+                          description: TLS holds various configurable Envoy TLS listener
+                            values.
+                          properties:
+                            cipherSuites:
+                              description: "CipherSuites defines the TLS ciphers to
+                              be supported by Envoy TLS listeners when negotiating
+                              TLS 1.2. Ciphers are validated against the set that
+                              Envoy supports by default. This parameter should only
+                              be used by advanced users. Note that these will be ignored
+                              when TLS 1.3 is in use. \n This field is optional; when
+                              it is undefined, a Contour-managed ciphersuite list
+                              will be used, which may be updated to keep it secure.
+                              \n Contour's default list is: - \"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]\"
+                              - \"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]\"
+                              - \"ECDHE-ECDSA-AES256-GCM-SHA384\" - \"ECDHE-RSA-AES256-GCM-SHA384\"
+                              \n Ciphers provided are validated against the following
+                              list: - \"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]\"
+                              - \"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]\"
+                              - \"ECDHE-ECDSA-AES128-GCM-SHA256\" - \"ECDHE-RSA-AES128-GCM-SHA256\"
+                              - \"ECDHE-ECDSA-AES128-SHA\" - \"ECDHE-RSA-AES128-SHA\"
+                              - \"AES128-GCM-SHA256\" - \"AES128-SHA\" - \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+                              - \"ECDHE-RSA-AES256-GCM-SHA384\" - \"ECDHE-ECDSA-AES256-SHA\"
+                              - \"ECDHE-RSA-AES256-SHA\" - \"AES256-GCM-SHA384\" -
+                              \"AES256-SHA\" \n Contour recommends leaving this undefined
+                              unless you are sure you must. \n See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
+                              Note: This list is a superset of what is valid for stock
+                              Envoy builds and those using BoringSSL FIPS."
+                              items:
+                                type: string
+                              type: array
+                            minimumProtocolVersion:
+                              description: "MinimumProtocolVersion is the minimum TLS
+                              version this vhost should negotiate. \n Values: `1.2`
+                              (default), `1.3`. \n Other values will produce an error."
+                              type: string
+                          type: object
+                        useProxyProtocol:
+                          description: "Use PROXY protocol for all listeners. \n Contour's
+                          default is false."
+                          type: boolean
+                      type: object
+                    logging:
+                      description: Logging defines how Envoy's logs can be configured.
+                      properties:
+                        accessLogFormat:
+                          description: "AccessLogFormat sets the global access log format.
+                          \n Values: `envoy` (default), `json`. \n Other values will
+                          produce an error."
+                          type: string
+                        accessLogFormatString:
+                          description: AccessLogFormatString sets the access log format
+                            when format is set to `envoy`. When empty, Envoy's default
+                            format is used.
+                          type: string
+                        accessLogJSONFields:
+                          description: AccessLogJSONFields sets the fields that JSON
+                            logging will output when AccessLogFormat is json.
+                          items:
+                            type: string
+                          type: array
+                        accessLogLevel:
+                          description: "AccessLogLevel sets the verbosity level of the
+                          access log. \n Values: `info` (default, all requests are
+                          logged), `error` (all non-success requests, i.e. 300+ response
+                          code, are logged), `critical` (all 5xx requests are logged)
+                          and `disabled`. \n Other values will produce an error."
+                          type: string
+                      type: object
+                    metrics:
+                      description: "Metrics defines the endpoint Envoy uses to serve
+                      metrics. \n Contour's default is { address: \"0.0.0.0\", port:
+                      8002 }."
+                      properties:
+                        address:
+                          description: Defines the metrics address interface.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Defines the metrics port.
+                          type: integer
+                        tls:
+                          description: TLS holds TLS file config details. Metrics and
+                            health endpoints cannot have same port number when metrics
+                            is served over HTTPS.
+                          properties:
+                            caFile:
+                              description: CA filename.
+                              type: string
+                            certFile:
+                              description: Client certificate filename.
+                              type: string
+                            keyFile:
+                              description: Client key filename.
+                              type: string
+                          type: object
+                      type: object
+                    network:
+                      description: Network holds various configurable Envoy network
+                        values.
+                      properties:
+                        adminPort:
+                          description: "Configure the port used to access the Envoy
+                          Admin interface. If configured to port \"0\" then the admin
+                          interface is disabled. \n Contour's default is 9001."
+                          type: integer
+                        numTrustedHops:
+                          description: "XffNumTrustedHops defines the number of additional
+                          ingress proxy hops from the right side of the x-forwarded-for
+                          HTTP header to trust when determining the origin client’s
+                          IP address. \n See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
+                          for more information. \n Contour's default is 0."
+                          format: int32
+                          type: integer
+                      type: object
+                    service:
+                      description: "Service holds Envoy service parameters for setting
+                      Ingress status. \n Contour's default is { namespace: \"projectcontour\",
+                      name: \"envoy\" }."
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - namespace
+                      type: object
+                    timeouts:
+                      description: Timeouts holds various configurable timeouts that
+                        can be set in the config file.
+                      properties:
+                        connectTimeout:
+                          description: "ConnectTimeout defines how long the proxy should
+                          wait when establishing connection to upstream service. If
+                          not set, a default value of 2 seconds will be used. \n See
+                          https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-connect-timeout
+                          for more information."
+                          type: string
+                        connectionIdleTimeout:
+                          description: "ConnectionIdleTimeout defines how long the proxy
+                          should wait while there are no active requests (for HTTP/1.1)
+                          or streams (for HTTP/2) before terminating an HTTP connection.
+                          Set to \"infinity\" to disable the timeout entirely. \n
+                          See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
+                          for more information."
+                          type: string
+                        connectionShutdownGracePeriod:
+                          description: "ConnectionShutdownGracePeriod defines how long
+                          the proxy will wait between sending an initial GOAWAY frame
+                          and a second, final GOAWAY frame when terminating an HTTP/2
+                          connection. During this grace period, the proxy will continue
+                          to respond to new streams. After the final GOAWAY frame
+                          has been sent, the proxy will refuse new streams. \n See
+                          https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-drain-timeout
+                          for more information."
+                          type: string
+                        delayedCloseTimeout:
+                          description: "DelayedCloseTimeout defines how long envoy will
+                          wait, once connection close processing has been initiated,
+                          for the downstream peer to close the connection before Envoy
+                          closes the socket associated with the connection. \n Setting
+                          this timeout to 'infinity' will disable it, equivalent to
+                          setting it to '0' in Envoy. Leaving it unset will result
+                          in the Envoy default value being used. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-delayed-close-timeout
+                          for more information."
+                          type: string
+                        maxConnectionDuration:
+                          description: "MaxConnectionDuration defines the maximum period
+                          of time after an HTTP connection has been established from
+                          the client to the proxy before it is closed by the proxy,
+                          regardless of whether there has been activity or not. Omit
+                          or set to \"infinity\" for no max duration. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration
+                          for more information."
+                          type: string
+                        requestTimeout:
+                          description: "RequestTimeout sets the client request timeout
+                          globally for Contour. Note that this is a timeout for the
+                          entire request, not an idle timeout. Omit or set to \"infinity\"
+                          to disable the timeout entirely. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-request-timeout
+                          for more information."
+                          type: string
+                        streamIdleTimeout:
+                          description: "StreamIdleTimeout defines how long the proxy
+                          should wait while there is no request activity (for HTTP/1.1)
+                          or stream activity (for HTTP/2) before terminating the HTTP
+                          request or stream. Set to \"infinity\" to disable the timeout
+                          entirely. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
+                          for more information."
+                          type: string
+                      type: object
+                  type: object
+                gateway:
+                  description: Gateway contains parameters for the gateway-api Gateway
+                    that Contour is configured to serve traffic.
+                  properties:
+                    controllerName:
+                      description: ControllerName is used to determine whether Contour
+                        should reconcile a GatewayClass. The string takes the form of
+                        "projectcontour.io/<namespace>/contour". If unset, the gatewayclass
+                        controller will not be started. Exactly one of ControllerName
+                        or GatewayRef must be set.
+                      type: string
+                    gatewayRef:
+                      description: GatewayRef defines a specific Gateway that this Contour
+                        instance corresponds to. If set, Contour will reconcile only
+                        this gateway, and will not reconcile any gateway classes. Exactly
+                        one of ControllerName or GatewayRef must be set.
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - namespace
+                      type: object
+                  type: object
+                globalExtAuth:
+                  description: GlobalExternalAuthorization allows envoys external authorization
+                    filter to be enabled for all virtual hosts.
+                  properties:
+                    authPolicy:
+                      description: AuthPolicy sets a default authorization policy for
+                        client requests. This policy will be used unless overridden
+                        by individual routes.
+                      properties:
+                        context:
+                          additionalProperties:
+                            type: string
+                          description: Context is a set of key/value pairs that are
+                            sent to the authentication server in the check request.
+                            If a context is provided at an enclosing scope, the entries
+                            are merged such that the inner scope overrides matching
+                            keys from the outer scope.
+                          type: object
+                        disabled:
+                          description: When true, this field disables client request
+                            authentication for the scope of the policy.
+                          type: boolean
+                      type: object
+                    extensionRef:
+                      description: ExtensionServiceRef specifies the extension resource
+                        that will authorize client requests.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent. If this field is
+                            not specified, the default "projectcontour.io/v1alpha1"
+                            will be used
+                          minLength: 1
+                          type: string
+                        name:
+                          description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace of the referent. If this field is
+                          not specifies, the namespace of the resource that targets
+                          the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                          minLength: 1
+                          type: string
+                      type: object
+                    failOpen:
+                      description: If FailOpen is true, the client request is forwarded
+                        to the upstream service even if the authorization server fails
+                        to respond. This field should not be set in most cases. It is
+                        intended for use only while migrating applications from internal
+                        authorization to Contour external authorization.
+                      type: boolean
+                    responseTimeout:
+                      description: ResponseTimeout configures maximum time to wait for
+                        a check response from the authorization server. Timeout durations
+                        are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                        Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                        The string "infinity" is also a valid input and specifies no
+                        timeout.
+                      pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                      type: string
+                    withRequestBody:
+                      description: WithRequestBody specifies configuration for sending
+                        the client request's body to authorization server.
+                      properties:
+                        allowPartialMessage:
+                          description: If AllowPartialMessage is true, then Envoy will
+                            buffer the body until MaxRequestBytes are reached.
+                          type: boolean
+                        maxRequestBytes:
+                          default: 1024
+                          description: MaxRequestBytes sets the maximum size of message
+                            body ExtAuthz filter will hold in-memory.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        packAsBytes:
+                          description: If PackAsBytes is true, the body sent to Authorization
+                            Server is in raw bytes.
+                          type: boolean
+                      type: object
+                  type: object
+                health:
+                  description: "Health defines the endpoints Contour uses to serve health
+                  checks. \n Contour's default is { address: \"0.0.0.0\", port: 8000
+                  }."
+                  properties:
+                    address:
+                      description: Defines the health address interface.
+                      minLength: 1
+                      type: string
+                    port:
+                      description: Defines the health port.
+                      type: integer
+                  type: object
+                httpproxy:
+                  description: HTTPProxy defines parameters on HTTPProxy.
+                  properties:
+                    disablePermitInsecure:
+                      description: "DisablePermitInsecure disables the use of the permitInsecure
+                      field in HTTPProxy. \n Contour's default is false."
+                      type: boolean
+                    fallbackCertificate:
+                      description: FallbackCertificate defines the namespace/name of
+                        the Kubernetes secret to use as fallback when a non-SNI request
+                        is received.
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - namespace
+                      type: object
+                    rootNamespaces:
+                      description: Restrict Contour to searching these namespaces for
+                        root ingress routes.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                ingress:
+                  description: Ingress contains parameters for ingress options.
+                  properties:
+                    classNames:
+                      description: Ingress Class Names Contour should use.
+                      items:
+                        type: string
+                      type: array
+                    statusAddress:
+                      description: Address to set in Ingress object status.
+                      type: string
+                  type: object
+                metrics:
+                  description: "Metrics defines the endpoint Contour uses to serve metrics.
+                  \n Contour's default is { address: \"0.0.0.0\", port: 8000 }."
+                  properties:
+                    address:
+                      description: Defines the metrics address interface.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    port:
+                      description: Defines the metrics port.
+                      type: integer
+                    tls:
+                      description: TLS holds TLS file config details. Metrics and health
+                        endpoints cannot have same port number when metrics is served
+                        over HTTPS.
+                      properties:
+                        caFile:
+                          description: CA filename.
+                          type: string
+                        certFile:
+                          description: Client certificate filename.
+                          type: string
+                        keyFile:
+                          description: Client key filename.
+                          type: string
+                      type: object
+                  type: object
+                policy:
+                  description: Policy specifies default policy applied if not overridden
+                    by the user
+                  properties:
+                    applyToIngress:
+                      description: "ApplyToIngress determines if the Policies will apply
+                      to ingress objects \n Contour's default is false."
+                      type: boolean
+                    requestHeaders:
+                      description: RequestHeadersPolicy defines the request headers
+                        set/removed on all routes
+                      properties:
+                        remove:
+                          items:
+                            type: string
+                          type: array
+                        set:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    responseHeaders:
+                      description: ResponseHeadersPolicy defines the response headers
+                        set/removed on all routes
+                      properties:
+                        remove:
+                          items:
+                            type: string
+                          type: array
+                        set:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                  type: object
+                rateLimitService:
+                  description: RateLimitService optionally holds properties of the Rate
+                    Limit Service to be used for global rate limiting.
+                  properties:
+                    defaultGlobalRateLimitPolicy:
+                      description: DefaultGlobalRateLimitPolicy allows setting a default
+                        global rate limit policy for every HTTPProxy. HTTPProxy can
+                        overwrite this configuration.
+                      properties:
+                        descriptors:
+                          description: Descriptors defines the list of descriptors that
+                            will be generated and sent to the rate limit service. Each
+                            descriptor contains 1+ key-value pair entries.
+                          items:
+                            description: RateLimitDescriptor defines a list of key-value
+                              pair generators.
+                            properties:
+                              entries:
+                                description: Entries is the list of key-value pair generators.
+                                items:
+                                  description: RateLimitDescriptorEntry is a key-value
+                                    pair generator. Exactly one field on this struct
+                                    must be non-nil.
+                                  properties:
+                                    genericKey:
+                                      description: GenericKey defines a descriptor entry
+                                        with a static key and value.
+                                      properties:
+                                        key:
+                                          description: Key defines the key of the descriptor
+                                            entry. If not set, the key is set to "generic_key".
+                                          type: string
+                                        value:
+                                          description: Value defines the value of the
+                                            descriptor entry.
+                                          minLength: 1
+                                          type: string
+                                      type: object
+                                    remoteAddress:
+                                      description: RemoteAddress defines a descriptor
+                                        entry with a key of "remote_address" and a value
+                                        equal to the client's IP address (from x-forwarded-for).
+                                      type: object
+                                    requestHeader:
+                                      description: RequestHeader defines a descriptor
+                                        entry that's populated only if a given header
+                                        is present on the request. The descriptor key
+                                        is static, and the descriptor value is equal
+                                        to the value of the header.
+                                      properties:
+                                        descriptorKey:
+                                          description: DescriptorKey defines the key
+                                            to use on the descriptor entry.
+                                          minLength: 1
+                                          type: string
+                                        headerName:
+                                          description: HeaderName defines the name of
+                                            the header to look for on the request.
+                                          minLength: 1
+                                          type: string
+                                      type: object
+                                    requestHeaderValueMatch:
+                                      description: RequestHeaderValueMatch defines a
+                                        descriptor entry that's populated if the request's
+                                        headers match a set of 1+ match criteria. The
+                                        descriptor key is "header_match", and the descriptor
+                                        value is static.
+                                      properties:
+                                        expectMatch:
+                                          default: true
+                                          description: ExpectMatch defines whether the
+                                            request must positively match the match
+                                            criteria in order to generate a descriptor
+                                            entry (i.e. true), or not match the match
+                                            criteria in order to generate a descriptor
+                                            entry (i.e. false). The default is true.
+                                          type: boolean
+                                        headers:
+                                          description: Headers is a list of 1+ match
+                                            criteria to apply against the request to
+                                            determine whether to populate the descriptor
+                                            entry or not.
+                                          items:
+                                            description: HeaderMatchCondition specifies
+                                              how to conditionally match against HTTP
+                                              headers. The Name field is required, but
+                                              only one of the remaining fields should
+                                              be be provided.
+                                            properties:
+                                              contains:
+                                                description: Contains specifies a substring
+                                                  that must be present in the header
+                                                  value.
+                                                type: string
+                                              exact:
+                                                description: Exact specifies a string
+                                                  that the header value must be equal
+                                                  to.
+                                                type: string
+                                              name:
+                                                description: Name is the name of the
+                                                  header to match against. Name is required.
+                                                  Header names are case insensitive.
+                                                type: string
+                                              notcontains:
+                                                description: NotContains specifies a
+                                                  substring that must not be present
+                                                  in the header value.
+                                                type: string
+                                              notexact:
+                                                description: NoExact specifies a string
+                                                  that the header value must not be
+                                                  equal to. The condition is true if
+                                                  the header has any other value.
+                                                type: string
+                                              notpresent:
+                                                description: NotPresent specifies that
+                                                  condition is true when the named header
+                                                  is not present. Note that setting
+                                                  NotPresent to false does not make
+                                                  the condition true if the named header
+                                                  is present.
+                                                type: boolean
+                                              present:
+                                                description: Present specifies that
+                                                  condition is true when the named header
+                                                  is present, regardless of its value.
+                                                  Note that setting Present to false
+                                                  does not make the condition true if
+                                                  the named header is absent.
+                                                type: boolean
+                                              regex:
+                                                description: Regex specifies a regular
+                                                  expression pattern that must match
+                                                  the header value.
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                          minItems: 1
+                                          type: array
+                                        value:
+                                          description: Value defines the value of the
+                                            descriptor entry.
+                                          minLength: 1
+                                          type: string
+                                      type: object
+                                  type: object
+                                minItems: 1
+                                type: array
+                            type: object
+                          minItems: 1
+                          type: array
+                        disabled:
+                          description: Disabled configures the HTTPProxy to not use
+                            the default global rate limit policy defined by the Contour
+                            configuration.
+                          type: boolean
+                      type: object
+                    domain:
+                      description: Domain is passed to the Rate Limit Service.
+                      type: string
+                    enableResourceExhaustedCode:
+                      description: EnableResourceExhaustedCode enables translating error
+                        code 429 to grpc code RESOURCE_EXHAUSTED. When disabled it's
+                        translated to UNAVAILABLE
+                      type: boolean
+                    enableXRateLimitHeaders:
+                      description: "EnableXRateLimitHeaders defines whether to include
+                      the X-RateLimit headers X-RateLimit-Limit, X-RateLimit-Remaining,
+                      and X-RateLimit-Reset (as defined by the IETF Internet-Draft
+                      linked below), on responses to clients when the Rate Limit Service
+                      is consulted for a request. \n ref. https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html"
+                      type: boolean
+                    extensionService:
+                      description: ExtensionService identifies the extension service
+                        defining the RLS.
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - namespace
+                      type: object
+                    failOpen:
+                      description: FailOpen defines whether to allow requests to proceed
+                        when the Rate Limit Service fails to respond with a valid rate
+                        limit decision within the timeout defined on the extension service.
+                      type: boolean
+                  required:
+                    - extensionService
+                  type: object
+                tracing:
+                  description: Tracing defines properties for exporting trace data to
+                    OpenTelemetry.
+                  properties:
+                    customTags:
+                      description: CustomTags defines a list of custom tags with unique
+                        tag name.
+                      items:
+                        description: CustomTag defines custom tags with unique tag name
+                          to create tags for the active span.
+                        properties:
+                          literal:
+                            description: Literal is a static custom tag value. Precisely
+                              one of Literal, RequestHeaderName must be set.
+                            type: string
+                          requestHeaderName:
+                            description: RequestHeaderName indicates which request header
+                              the label value is obtained from. Precisely one of Literal,
+                              RequestHeaderName must be set.
+                            type: string
+                          tagName:
+                            description: TagName is the unique name of the custom tag.
+                            type: string
+                        required:
+                          - tagName
+                        type: object
+                      type: array
+                    extensionService:
+                      description: ExtensionService identifies the extension service
+                        defining the otel-collector.
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - namespace
+                      type: object
+                    includePodDetail:
+                      description: 'IncludePodDetail defines a flag. If it is true,
+                      contour will add the pod name and namespace to the span of the
+                      trace. the default is true. Note: The Envoy pods MUST have the
+                      HOSTNAME and CONTOUR_NAMESPACE environment variables set for
+                      this to work properly.'
+                      type: boolean
+                    maxPathTagLength:
+                      description: MaxPathTagLength defines maximum length of the request
+                        path to extract and include in the HttpUrl tag. contour's default
+                        is 256.
+                      format: int32
+                      type: integer
+                    overallSampling:
+                      description: OverallSampling defines the sampling rate of trace
+                        data. contour's default is 100.
+                      type: string
+                    serviceName:
+                      description: ServiceName defines the name for the service. contour's
+                        default is contour.
+                      type: string
+                  required:
+                    - extensionService
+                  type: object
+                xdsServer:
+                  description: XDSServer contains parameters for the xDS server.
+                  properties:
+                    address:
+                      description: "Defines the xDS gRPC API address which Contour will
+                      serve. \n Contour's default is \"0.0.0.0\"."
+                      minLength: 1
+                      type: string
+                    port:
+                      description: "Defines the xDS gRPC API port which Contour will
+                      serve. \n Contour's default is 8001."
+                      type: integer
+                    tls:
+                      description: "TLS holds TLS file config details. \n Contour's
+                      default is { caFile: \"/certs/ca.crt\", certFile: \"/certs/tls.cert\",
+                      keyFile: \"/certs/tls.key\", insecure: false }."
+                      properties:
+                        caFile:
+                          description: CA filename.
+                          type: string
+                        certFile:
+                          description: Client certificate filename.
+                          type: string
+                        insecure:
+                          description: Allow serving the xDS gRPC API without TLS.
+                          type: boolean
+                        keyFile:
+                          description: Client key filename.
+                          type: string
+                      type: object
+                    type:
+                      description: "Defines the XDSServer to use for `contour serve`.
+                      \n Values: `contour` (default), `envoy`. \n Other values will
+                      produce an error."
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: ContourConfigurationStatus defines the observed state of
+                a ContourConfiguration resource.
+              properties:
+                conditions:
+                  description: "Conditions contains the current status of the Contour
+                  resource. \n Contour will update a single condition, `Valid`, that
+                  is in normal-true polarity. \n Contour will not modify any other
+                  Conditions set in this block, in case some other controller wants
+                  to add a Condition."
+                  items:
+                    description: "DetailedCondition is an extension of the normal Kubernetes
+                    conditions, with two extra fields to hold sub-conditions, which
+                    provide more detailed reasons for the state (True or False) of
+                    the condition. \n `errors` holds information about sub-conditions
+                    which are fatal to that condition and render its state False.
+                    \n `warnings` holds information about sub-conditions which are
+                    not fatal to that condition and do not force the state to be False.
+                    \n Remember that Conditions have a type, a status, and a reason.
+                    \n The type is the type of the condition, the most important one
+                    in this CRD set is `Valid`. `Valid` is a positive-polarity condition:
+                    when it is `status: true` there are no problems. \n In more detail,
+                    `status: true` means that the object is has been ingested into
+                    Contour with no errors. `warnings` may still be present, and will
+                    be indicated in the Reason field. There must be zero entries in
+                    the `errors` slice in this case. \n `Valid`, `status: false` means
+                    that the object has had one or more fatal errors during processing
+                    into Contour. The details of the errors will be present under
+                    the `errors` field. There must be at least one error in the `errors`
+                    slice if `status` is `false`. \n For DetailedConditions of types
+                    other than `Valid`, the Condition must be in the negative polarity.
+                    When they have `status` `true`, there is an error. There must
+                    be at least one entry in the `errors` Subcondition slice. When
+                    they have `status` `false`, there are no serious errors, and there
+                    must be zero entries in the `errors` slice. In either case, there
+                    may be entries in the `warnings` slice. \n Regardless of the polarity,
+                    the `reason` and `message` fields must be updated with either
+                    the detail of the reason (if there is one and only one entry in
+                    total across both the `errors` and `warnings` slices), or `MultipleReasons`
+                    if there is more than one entry."
+                    properties:
+                      errors:
+                        description: "Errors contains a slice of relevant error subconditions
+                        for this object. \n Subconditions are expected to appear when
+                        relevant (when there is a error), and disappear when not relevant.
+                        An empty slice here indicates no errors."
+                        items:
+                          description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition
+                          transitioned from one status to another. This should be when
+                          the underlying condition changed.  If that is not known, then
+                          using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating
+                          details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if .metadata.generation
+                          is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition. Producers
+                          of specific condition types may define expected values and
+                          meanings for this field, and whether the values are considered
+                          a guaranteed API. The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          --- Many .condition.type values are consistent across resources
+                          like Available, but because arbitrary conditions can be useful
+                          (see .node.status.conditions), the ability to deconflict is
+                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                      warnings:
+                        description: "Warnings contains a slice of relevant warning
+                        subconditions for this object. \n Subconditions are expected
+                        to appear when relevant (when there is a warning), and disappear
+                        when not relevant. An empty slice here indicates no warnings."
+                        items:
+                          description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: contourdeployments.projectcontour.io
+spec:
+  preserveUnknownFields: false
+  group: projectcontour.io
+  names:
+    kind: ContourDeployment
+    listKind: ContourDeploymentList
+    plural: contourdeployments
+    shortNames:
+      - contourdeploy
+    singular: contourdeployment
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ContourDeployment is the schema for a Contour Deployment.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ContourDeploymentSpec specifies options for how a Contour
+                instance should be provisioned.
+              properties:
+                contour:
+                  description: Contour specifies deployment-time settings for the Contour
+                    part of the installation, i.e. the xDS server/control plane and
+                    associated resources, including things like replica count for the
+                    Deployment, and node placement constraints for the pods.
+                  properties:
+                    deployment:
+                      description: Deployment describes the settings for running contour
+                        as a `Deployment`.
+                      properties:
+                        replicas:
+                          description: Replicas is the desired number of replicas.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        strategy:
+                          description: Strategy describes the deployment strategy to
+                            use to replace existing pods with new pods.
+                          properties:
+                            rollingUpdate:
+                              description: 'Rolling update config params. Present only
+                              if DeploymentStrategyType = RollingUpdate. --- TODO:
+                              Update this to follow our convention for oneOf, whatever
+                              we decide it to be.'
+                              properties:
+                                maxSurge:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: 'The maximum number of pods that can
+                                  be scheduled above the desired number of pods. Value
+                                  can be an absolute number (ex: 5) or a percentage
+                                  of desired pods (ex: 10%). This can not be 0 if
+                                  MaxUnavailable is 0. Absolute number is calculated
+                                  from percentage by rounding up. Defaults to 25%.
+                                  Example: when this is set to 30%, the new ReplicaSet
+                                  can be scaled up immediately when the rolling update
+                                  starts, such that the total number of old and new
+                                  pods do not exceed 130% of desired pods. Once old
+                                  pods have been killed, new ReplicaSet can be scaled
+                                  up further, ensuring that total number of pods running
+                                  at any time during the update is at most 130% of
+                                  desired pods.'
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: 'The maximum number of pods that can
+                                  be unavailable during the update. Value can be an
+                                  absolute number (ex: 5) or a percentage of desired
+                                  pods (ex: 10%). Absolute number is calculated from
+                                  percentage by rounding down. This can not be 0 if
+                                  MaxSurge is 0. Defaults to 25%. Example: when this
+                                  is set to 30%, the old ReplicaSet can be scaled
+                                  down to 70% of desired pods immediately when the
+                                  rolling update starts. Once new pods are ready,
+                                  old ReplicaSet can be scaled down further, followed
+                                  by scaling up the new ReplicaSet, ensuring that
+                                  the total number of pods available at all times
+                                  during the update is at least 70% of desired pods.'
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: Type of deployment. Can be "Recreate" or
+                                "RollingUpdate". Default is RollingUpdate.
+                              type: string
+                          type: object
+                      type: object
+                    kubernetesLogLevel:
+                      description: KubernetesLogLevel Enable Kubernetes client debug
+                        logging with log level. If unset, defaults to 0.
+                      maximum: 9
+                      minimum: 0
+                      type: integer
+                    logLevel:
+                      description: LogLevel sets the log level for Contour Allowed values
+                        are "info", "debug".
+                      type: string
+                    nodePlacement:
+                      description: NodePlacement describes node scheduling configuration
+                        of Contour pods.
+                      properties:
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          description: "NodeSelector is the simplest recommended form
+                          of node selection constraint and specifies a map of key-value
+                          pairs. For the pod to be eligible to run on a node, the
+                          node must have each of the indicated key-value pairs as
+                          labels (it can have additional labels as well). \n If unset,
+                          the pod(s) will be scheduled to any available node."
+                          type: object
+                        tolerations:
+                          description: "Tolerations work with taints to ensure that
+                          pods are not scheduled onto inappropriate nodes. One or
+                          more taints are applied to a node; this marks that the node
+                          should not accept any pods that do not tolerate the taints.
+                          \n The default is an empty list. \n See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                          for additional details."
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect> using
+                              the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match.
+                                  Empty means match all taint effects. When specified,
+                                  allowed values are NoSchedule, PreferNoSchedule and
+                                  NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If the
+                                  key is empty, operator must be Exists; this combination
+                                  means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints of
+                                  a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect NoExecute,
+                                  otherwise this field is ignored) tolerates the taint.
+                                  By default, it is not set, which means tolerate the
+                                  taint forever (do not evict). Zero and negative values
+                                  will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value should
+                                  be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    podAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: PodAnnotations defines annotations to add to the
+                        Contour pods. the annotations for Prometheus will be appended
+                        or overwritten with predefined value.
+                      type: object
+                    replicas:
+                      description: "Deprecated: Use `DeploymentSettings.Replicas` instead.
+                      \n Replicas is the desired number of Contour replicas. If if
+                      unset, defaults to 2. \n if both `DeploymentSettings.Replicas`
+                      and this one is set, use `DeploymentSettings.Replicas`."
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    resources:
+                      description: 'Compute Resources required by contour container.
+                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      properties:
+                        claims:
+                          description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: Name must match the name of one entry in
+                                  pod.spec.resourceClaims of the Pod where this field
+                                  is used. It makes that resource available inside a
+                                  container.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                  type: object
+                envoy:
+                  description: Envoy specifies deployment-time settings for the Envoy
+                    part of the installation, i.e. the xDS client/data plane and associated
+                    resources, including things like the workload type to use (DaemonSet
+                    or Deployment), node placement constraints for the pods, and various
+                    options for the Envoy service.
+                  properties:
+                    daemonSet:
+                      description: DaemonSet describes the settings for running envoy
+                        as a `DaemonSet`. if `WorkloadType` is `Deployment`,it's must
+                        be nil
+                      properties:
+                        updateStrategy:
+                          description: Strategy describes the deployment strategy to
+                            use to replace existing DaemonSet pods with new pods.
+                          properties:
+                            rollingUpdate:
+                              description: 'Rolling update config params. Present only
+                              if type = "RollingUpdate". --- TODO: Update this to
+                              follow our convention for oneOf, whatever we decide
+                              it to be. Same as Deployment `strategy.rollingUpdate`.
+                              See https://github.com/kubernetes/kubernetes/issues/35345'
+                              properties:
+                                maxSurge:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: 'The maximum number of nodes with an
+                                  existing available DaemonSet pod that can have an
+                                  updated DaemonSet pod during during an update. Value
+                                  can be an absolute number (ex: 5) or a percentage
+                                  of desired pods (ex: 10%). This can not be 0 if
+                                  MaxUnavailable is 0. Absolute number is calculated
+                                  from percentage by rounding up to a minimum of 1.
+                                  Default value is 0. Example: when this is set to
+                                  30%, at most 30% of the total number of nodes that
+                                  should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                                  can have their a new pod created before the old
+                                  pod is marked as deleted. The update starts by launching
+                                  new pods on 30% of nodes. Once an updated pod is
+                                  available (Ready for at least minReadySeconds) the
+                                  old DaemonSet pod on that node is marked deleted.
+                                  If the old pod becomes unavailable for any reason
+                                  (Ready transitions to false, is evicted, or is drained)
+                                  an updated pod is immediatedly created on that node
+                                  without considering surge limits. Allowing surge
+                                  implies the possibility that the resources consumed
+                                  by the daemonset on any given node can double if
+                                  the readiness check fails, and so resource intensive
+                                  daemonsets should take into account that they may
+                                  cause evictions during disruption.'
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: 'The maximum number of DaemonSet pods
+                                  that can be unavailable during the update. Value
+                                  can be an absolute number (ex: 5) or a percentage
+                                  of total number of DaemonSet pods at the start of
+                                  the update (ex: 10%). Absolute number is calculated
+                                  from percentage by rounding up. This cannot be 0
+                                  if MaxSurge is 0 Default value is 1. Example: when
+                                  this is set to 30%, at most 30% of the total number
+                                  of nodes that should be running the daemon pod (i.e.
+                                  status.desiredNumberScheduled) can have their pods
+                                  stopped for an update at any given time. The update
+                                  starts by stopping at most 30% of those DaemonSet
+                                  pods and then brings up new DaemonSet pods in their
+                                  place. Once the new pods are available, it then
+                                  proceeds onto other DaemonSet pods, thus ensuring
+                                  that at least 70% of original number of DaemonSet
+                                  pods are available at all times during the update.'
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: Type of daemon set update. Can be "RollingUpdate"
+                                or "OnDelete". Default is RollingUpdate.
+                              type: string
+                          type: object
+                      type: object
+                    deployment:
+                      description: Deployment describes the settings for running envoy
+                        as a `Deployment`. if `WorkloadType` is `DaemonSet`,it's must
+                        be nil
+                      properties:
+                        replicas:
+                          description: Replicas is the desired number of replicas.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        strategy:
+                          description: Strategy describes the deployment strategy to
+                            use to replace existing pods with new pods.
+                          properties:
+                            rollingUpdate:
+                              description: 'Rolling update config params. Present only
+                              if DeploymentStrategyType = RollingUpdate. --- TODO:
+                              Update this to follow our convention for oneOf, whatever
+                              we decide it to be.'
+                              properties:
+                                maxSurge:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: 'The maximum number of pods that can
+                                  be scheduled above the desired number of pods. Value
+                                  can be an absolute number (ex: 5) or a percentage
+                                  of desired pods (ex: 10%). This can not be 0 if
+                                  MaxUnavailable is 0. Absolute number is calculated
+                                  from percentage by rounding up. Defaults to 25%.
+                                  Example: when this is set to 30%, the new ReplicaSet
+                                  can be scaled up immediately when the rolling update
+                                  starts, such that the total number of old and new
+                                  pods do not exceed 130% of desired pods. Once old
+                                  pods have been killed, new ReplicaSet can be scaled
+                                  up further, ensuring that total number of pods running
+                                  at any time during the update is at most 130% of
+                                  desired pods.'
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: 'The maximum number of pods that can
+                                  be unavailable during the update. Value can be an
+                                  absolute number (ex: 5) or a percentage of desired
+                                  pods (ex: 10%). Absolute number is calculated from
+                                  percentage by rounding down. This can not be 0 if
+                                  MaxSurge is 0. Defaults to 25%. Example: when this
+                                  is set to 30%, the old ReplicaSet can be scaled
+                                  down to 70% of desired pods immediately when the
+                                  rolling update starts. Once new pods are ready,
+                                  old ReplicaSet can be scaled down further, followed
+                                  by scaling up the new ReplicaSet, ensuring that
+                                  the total number of pods available at all times
+                                  during the update is at least 70% of desired pods.'
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: Type of deployment. Can be "Recreate" or
+                                "RollingUpdate". Default is RollingUpdate.
+                              type: string
+                          type: object
+                      type: object
+                    extraVolumeMounts:
+                      description: ExtraVolumeMounts holds the extra volume mounts to
+                        add (normally used with extraVolumes).
+                      items:
+                        description: VolumeMount describes a mounting of a Volume within
+                          a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other way
+                              around. When not set, MountPropagationNone is used. This
+                              field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive.
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
+                    extraVolumes:
+                      description: ExtraVolumes holds the extra volumes to add.
+                      items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod.
+                        properties:
+                          awsElasticBlockStore:
+                            description: 'awsElasticBlockStore represents an AWS Disk
+                            resource that is attached to a kubelet''s host machine
+                            and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                TODO: how do we prevent errors in the filesystem from
+                                compromising the machine'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty).'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly value true will force the readOnly
+                                setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: boolean
+                              volumeID:
+                                description: 'volumeID is unique ID of the persistent
+                                disk resource in AWS (Amazon EBS volume). More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                            required:
+                              - volumeID
+                            type: object
+                          azureDisk:
+                            description: azureDisk represents an Azure Data Disk mount
+                              on the host and bind mount to the pod.
+                            properties:
+                              cachingMode:
+                                description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
+                                type: string
+                              diskName:
+                                description: diskName is the Name of the data disk in
+                                  the blob storage
+                                type: string
+                              diskURI:
+                                description: diskURI is the URI of data disk in the
+                                  blob storage
+                                type: string
+                              fsType:
+                                description: fsType is Filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              kind:
+                                description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage account  Managed: azure managed
+                                data disk (only in managed availability set). defaults
+                                to shared'
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                            required:
+                              - diskName
+                              - diskURI
+                            type: object
+                          azureFile:
+                            description: azureFile represents an Azure File Service
+                              mount on the host and bind mount to the pod.
+                            properties:
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretName:
+                                description: secretName is the  name of secret that
+                                  contains Azure Storage Account Name and Key
+                                type: string
+                              shareName:
+                                description: shareName is the azure share Name
+                                type: string
+                            required:
+                              - secretName
+                              - shareName
+                            type: object
+                          cephfs:
+                            description: cephFS represents a Ceph FS mount on the host
+                              that shares a pod's lifetime
+                            properties:
+                              monitors:
+                                description: 'monitors is Required: Monitors is a collection
+                                of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              path:
+                                description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
+                                type: string
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: boolean
+                              secretFile:
+                                description: 'secretFile is Optional: SecretFile is
+                                the path to key ring for User, default is /etc/ceph/user.secret
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                              secretRef:
+                                description: 'secretRef is Optional: SecretRef is reference
+                                to the authentication secret for User, default is
+                                empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              user:
+                                description: 'user is optional: User is the rados user
+                                name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                            required:
+                              - monitors
+                            type: object
+                          cinder:
+                            description: 'cinder represents a cinder volume attached
+                            and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                              readOnly:
+                                description: 'readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is optional: points to a secret
+                                object containing parameters used to connect to OpenStack.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              volumeID:
+                                description: 'volumeID used to identify the volume in
+                                cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                            required:
+                              - volumeID
+                            type: object
+                          configMap:
+                            description: configMap represents a configMap that should
+                              populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items if unspecified, each key-value pair
+                                  in the Data field of the referenced ConfigMap will
+                                  be projected into the volume as a file whose name
+                                  is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If a
+                                  key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked optional.
+                                  Paths must be relative and may not contain the '..'
+                                  path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within a
+                                    volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap
+                                  or its keys must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          csi:
+                            description: csi (Container Storage Interface) represents
+                              ephemeral storage that is handled by certain external
+                              CSI drivers (Beta feature).
+                            properties:
+                              driver:
+                                description: driver is the name of the CSI driver that
+                                  handles this volume. Consult with your admin for the
+                                  correct name as registered in the cluster.
+                                type: string
+                              fsType:
+                                description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                  If not provided, the empty value is passed to the
+                                  associated CSI driver which will determine the default
+                                  filesystem to apply.
+                                type: string
+                              nodePublishSecretRef:
+                                description: nodePublishSecretRef is a reference to
+                                  the secret object containing sensitive information
+                                  to pass to the CSI driver to complete the CSI NodePublishVolume
+                                  and NodeUnpublishVolume calls. This field is optional,
+                                  and  may be empty if no secret is required. If the
+                                  secret object contains more than one secret, all secret
+                                  references are passed.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              readOnly:
+                                description: readOnly specifies a read-only configuration
+                                  for the volume. Defaults to false (read/write).
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                description: volumeAttributes stores driver-specific
+                                  properties that are passed to the CSI driver. Consult
+                                  your driver's documentation for supported values.
+                                type: object
+                            required:
+                              - driver
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI represents downward API about the
+                              pod that should populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'Optional: mode bits to use on created
+                                files by default. Must be a Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: Items is a list of downward API volume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name and namespace
+                                      are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                        - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                      permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, requests.cpu and requests.memory)
+                                      are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                        - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                    - path
+                                  type: object
+                                type: array
+                            type: object
+                          emptyDir:
+                            description: 'emptyDir represents a temporary directory
+                            that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            properties:
+                              medium:
+                                description: 'medium represents what type of storage
+                                medium should back this directory. The default is
+                                "" which means to use the node''s default medium.
+                                Must be an empty string (default) or Memory. More
+                                info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                type: string
+                              sizeLimit:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: 'sizeLimit is the total amount of local
+                                storage required for this EmptyDir volume. The size
+                                limit is also applicable for memory medium. The maximum
+                                usage on memory medium EmptyDir would be the minimum
+                                value between the SizeLimit specified here and the
+                                sum of memory limits of all containers in a pod. The
+                                default is nil which means that the limit is undefined.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            description: "ephemeral represents a volume that is handled
+                            by a cluster storage driver. The volume's lifecycle is
+                            tied to the pod that defines it - it will be created before
+                            the pod starts, and deleted when the pod is removed. \n
+                            Use this if: a) the volume is only needed while the pod
+                            runs, b) features of normal volumes like restoring from
+                            snapshot or capacity tracking are needed, c) the storage
+                            driver is specified through a storage class, and d) the
+                            storage driver supports dynamic volume provisioning through
+                            a PersistentVolumeClaim (see EphemeralVolumeSource for
+                            more information on the connection between this volume
+                            type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                            or one of the vendor-specific APIs for volumes that persist
+                            for longer than the lifecycle of an individual pod. \n
+                            Use CSI for light-weight local ephemeral volumes if the
+                            CSI driver is meant to be used that way - see the documentation
+                            of the driver for more information. \n A pod can use both
+                            types of ephemeral volumes and persistent volumes at the
+                            same time."
+                            properties:
+                              volumeClaimTemplate:
+                                description: "Will be used to create a stand-alone PVC
+                                to provision the volume. The pod in which this EphemeralVolumeSource
+                                is embedded will be the owner of the PVC, i.e. the
+                                PVC will be deleted together with the pod.  The name
+                                of the PVC will be `<pod name>-<volume name>` where
+                                `<volume name>` is the name from the `PodSpec.Volumes`
+                                array entry. Pod validation will reject the pod if
+                                the concatenated name is not valid for a PVC (for
+                                example, too long). \n An existing PVC with that name
+                                that is not owned by the pod will *not* be used for
+                                the pod to avoid using an unrelated volume by mistake.
+                                Starting the pod is then blocked until the unrelated
+                                PVC is removed. If such a pre-created PVC is meant
+                                to be used by the pod, the PVC has to updated with
+                                an owner reference to the pod once the pod exists.
+                                Normally this should not be necessary, but it may
+                                be useful when manually reconstructing a broken cluster.
+                                \n This field is read-only and no changes will be
+                                made by Kubernetes to the PVC after it has been created.
+                                \n Required, must not be nil."
+                                properties:
+                                  metadata:
+                                    description: May contain labels and annotations
+                                      that will be copied into the PVC when creating
+                                      it. No other fields are allowed and will be rejected
+                                      during validation.
+                                    type: object
+                                  spec:
+                                    description: The specification for the PersistentVolumeClaim.
+                                      The entire content is copied unchanged into the
+                                      PVC that gets created from this template. The
+                                      same fields as in a PersistentVolumeClaim are
+                                      also valid here.
+                                    properties:
+                                      accessModes:
+                                        description: 'accessModes contains the desired
+                                        access modes the volume should have. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        items:
+                                          type: string
+                                        type: array
+                                      dataSource:
+                                        description: 'dataSource field can be used to
+                                        specify either: * An existing VolumeSnapshot
+                                        object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        * An existing PVC (PersistentVolumeClaim)
+                                        If the provisioner or an external controller
+                                        can support the specified data source, it
+                                        will create a new volume based on the contents
+                                        of the specified data source. When the AnyVolumeDataSource
+                                        feature gate is enabled, dataSource contents
+                                        will be copied to dataSourceRef, and dataSourceRef
+                                        contents will be copied to dataSource when
+                                        dataSourceRef.namespace is not specified.
+                                        If the namespace is specified, then dataSourceRef
+                                        will not be copied to dataSource.'
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for the
+                                              resource being referenced. If APIGroup
+                                              is not specified, the specified Kind must
+                                              be in the core API group. For any other
+                                              third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        description: 'dataSourceRef specifies the object
+                                        from which to populate the volume with data,
+                                        if a non-empty volume is desired. This may
+                                        be any object from a non-empty API group (non
+                                        core object) or a PersistentVolumeClaim object.
+                                        When this field is specified, volume binding
+                                        will only succeed if the type of the specified
+                                        object matches some installed volume populator
+                                        or dynamic provisioner. This field will replace
+                                        the functionality of the dataSource field
+                                        and as such if both fields are non-empty,
+                                        they must have the same value. For backwards
+                                        compatibility, when namespace isn''t specified
+                                        in dataSourceRef, both fields (dataSource
+                                        and dataSourceRef) will be set to the same
+                                        value automatically if one of them is empty
+                                        and the other is non-empty. When namespace
+                                        is specified in dataSourceRef, dataSource
+                                        isn''t set to the same value and must be empty.
+                                        There are three important differences between
+                                        dataSource and dataSourceRef: * While dataSource
+                                        only allows two specific types of objects,
+                                        dataSourceRef allows any non-core object,
+                                        as well as PersistentVolumeClaim objects.
+                                        * While dataSource ignores disallowed values
+                                        (dropping them), dataSourceRef preserves all
+                                        values, and generates an error if a disallowed
+                                        value is specified. * While dataSource only
+                                        allows local objects, dataSourceRef allows
+                                        objects in any namespaces. (Beta) Using this
+                                        field requires the AnyVolumeDataSource feature
+                                        gate to be enabled. (Alpha) Using the namespace
+                                        field of dataSourceRef requires the CrossNamespaceVolumeDataSource
+                                        feature gate to be enabled.'
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for the
+                                              resource being referenced. If APIGroup
+                                              is not specified, the specified Kind must
+                                              be in the core API group. For any other
+                                              third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                          namespace:
+                                            description: Namespace is the namespace
+                                              of resource being referenced Note that
+                                              when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
+                                              object is required in the referent namespace
+                                              to allow that namespace's owner to accept
+                                              the reference. See the ReferenceGrant
+                                              documentation for details. (Alpha) This
+                                              field requires the CrossNamespaceVolumeDataSource
+                                              feature gate to be enabled.
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      resources:
+                                        description: 'resources represents the minimum
+                                        resources the volume should have. If RecoverVolumeExpansionFailure
+                                        feature is enabled users are allowed to specify
+                                        resource requirements that are lower than
+                                        previous value but must still be higher than
+                                        capacity recorded in the status field of the
+                                        claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        properties:
+                                          claims:
+                                            description: "Claims lists the names of
+                                            resources, defined in spec.resourceClaims,
+                                            that are used by this container. \n This
+                                            is an alpha field and requires enabling
+                                            the DynamicResourceAllocation feature
+                                            gate. \n This field is immutable. It can
+                                            only be set for containers."
+                                            items:
+                                              description: ResourceClaim references
+                                                one entry in PodSpec.ResourceClaims.
+                                              properties:
+                                                name:
+                                                  description: Name must match the name
+                                                    of one entry in pod.spec.resourceClaims
+                                                    of the Pod where this field is used.
+                                                    It makes that resource available
+                                                    inside a container.
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over
+                                          volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        description: 'storageClassName is the name of
+                                        the StorageClass required by the claim. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeMode:
+                                        description: volumeMode defines what type of
+                                          volume is required by the claim. Value of
+                                          Filesystem is implied when not included in
+                                          claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                required:
+                                  - spec
+                                type: object
+                            type: object
+                          fc:
+                            description: fc represents a Fibre Channel resource that
+                              is attached to a kubelet's host machine and then exposed
+                              to the pod.
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified. TODO: how do we prevent
+                                errors in the filesystem from compromising the machine'
+                                type: string
+                              lun:
+                                description: 'lun is Optional: FC target lun number'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
+                                type: boolean
+                              targetWWNs:
+                                description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
+                                items:
+                                  type: string
+                                type: array
+                              wwids:
+                                description: 'wwids Optional: FC volume world wide identifiers
+                                (wwids) Either wwids or combination of targetWWNs
+                                and lun must be set, but not both simultaneously.'
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          flexVolume:
+                            description: flexVolume represents a generic volume resource
+                              that is provisioned/attached using an exec based plugin.
+                            properties:
+                              driver:
+                                description: driver is the name of the driver to use
+                                  for this volume.
+                                type: string
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". The default filesystem
+                                  depends on FlexVolume script.
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                description: 'options is Optional: this field holds
+                                extra command options if any.'
+                                type: object
+                              readOnly:
+                                description: 'readOnly is Optional: defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is Optional: secretRef is reference
+                                to the secret object containing sensitive information
+                                to pass to the plugin scripts. This may be empty if
+                                no secret object is specified. If the secret object
+                                contains more than one secret, all secrets are passed
+                                to the plugin scripts.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                              - driver
+                            type: object
+                          flocker:
+                            description: flocker represents a Flocker volume attached
+                              to a kubelet's host machine. This depends on the Flocker
+                              control service being running
+                            properties:
+                              datasetName:
+                                description: datasetName is Name of the dataset stored
+                                  as metadata -> name on the dataset for Flocker should
+                                  be considered as deprecated
+                                type: string
+                              datasetUUID:
+                                description: datasetUUID is the UUID of the dataset.
+                                  This is unique identifier of a Flocker dataset
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            description: 'gcePersistentDisk represents a GCE Disk resource
+                            that is attached to a kubelet''s host machine and then
+                            exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            properties:
+                              fsType:
+                                description: 'fsType is filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                TODO: how do we prevent errors in the filesystem from
+                                compromising the machine'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                format: int32
+                                type: integer
+                              pdName:
+                                description: 'pdName is unique name of the PD resource
+                                in GCE. Used to identify the disk in GCE. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: boolean
+                            required:
+                              - pdName
+                            type: object
+                          gitRepo:
+                            description: 'gitRepo represents a git repository at a particular
+                            revision. DEPRECATED: GitRepo is deprecated. To provision
+                            a container with a git repo, mount an EmptyDir into an
+                            InitContainer that clones the repo using git, then mount
+                            the EmptyDir into the Pod''s container.'
+                            properties:
+                              directory:
+                                description: directory is the target directory name.
+                                  Must not contain or start with '..'.  If '.' is supplied,
+                                  the volume directory will be the git repository.  Otherwise,
+                                  if specified, the volume will contain the git repository
+                                  in the subdirectory with the given name.
+                                type: string
+                              repository:
+                                description: repository is the URL
+                                type: string
+                              revision:
+                                description: revision is the commit hash for the specified
+                                  revision.
+                                type: string
+                            required:
+                              - repository
+                            type: object
+                          glusterfs:
+                            description: 'glusterfs represents a Glusterfs mount on
+                            the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                            properties:
+                              endpoints:
+                                description: 'endpoints is the endpoint name that details
+                                Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              path:
+                                description: 'path is the Glusterfs volume path. More
+                                info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the Glusterfs
+                                volume to be mounted with read-only permissions. Defaults
+                                to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: boolean
+                            required:
+                              - endpoints
+                              - path
+                            type: object
+                          hostPath:
+                            description: 'hostPath represents a pre-existing file or
+                            directory on the host machine that is directly exposed
+                            to the container. This is generally used for system agents
+                            or other privileged things that are allowed to see the
+                            host machine. Most containers will NOT need this. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                            --- TODO(jonesdl) We need to restrict who can use host
+                            directory mounts and who can/can not mount host directories
+                            as read/write.'
+                            properties:
+                              path:
+                                description: 'path of the directory on the host. If
+                                the path is a symlink, it will follow the link to
+                                the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                              type:
+                                description: 'type for HostPath Volume Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                            required:
+                              - path
+                            type: object
+                          iscsi:
+                            description: 'iscsi represents an ISCSI Disk resource that
+                            is attached to a kubelet''s host machine and then exposed
+                            to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                            properties:
+                              chapAuthDiscovery:
+                                description: chapAuthDiscovery defines whether support
+                                  iSCSI Discovery CHAP authentication
+                                type: boolean
+                              chapAuthSession:
+                                description: chapAuthSession defines whether support
+                                  iSCSI Session CHAP authentication
+                                type: boolean
+                              fsType:
+                                description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                TODO: how do we prevent errors in the filesystem from
+                                compromising the machine'
+                                type: string
+                              initiatorName:
+                                description: initiatorName is the custom iSCSI Initiator
+                                  Name. If initiatorName is specified with iscsiInterface
+                                  simultaneously, new iSCSI interface <target portal>:<volume
+                                  name> will be created for the connection.
+                                type: string
+                              iqn:
+                                description: iqn is the target iSCSI Qualified Name.
+                                type: string
+                              iscsiInterface:
+                                description: iscsiInterface is the interface Name that
+                                  uses an iSCSI transport. Defaults to 'default' (tcp).
+                                type: string
+                              lun:
+                                description: lun represents iSCSI Target Lun number.
+                                format: int32
+                                type: integer
+                              portals:
+                                description: portals is the iSCSI Target Portal List.
+                                  The portal is either an IP or ip_addr:port if the
+                                  port is other than default (typically TCP ports 860
+                                  and 3260).
+                                items:
+                                  type: string
+                                type: array
+                              readOnly:
+                                description: readOnly here will force the ReadOnly setting
+                                  in VolumeMounts. Defaults to false.
+                                type: boolean
+                              secretRef:
+                                description: secretRef is the CHAP Secret for iSCSI
+                                  target and initiator authentication
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              targetPortal:
+                                description: targetPortal is iSCSI Target Portal. The
+                                  Portal is either an IP or ip_addr:port if the port
+                                  is other than default (typically TCP ports 860 and
+                                  3260).
+                                type: string
+                            required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                            type: object
+                          name:
+                            description: 'name of the volume. Must be a DNS_LABEL and
+                            unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          nfs:
+                            description: 'nfs represents an NFS mount on the host that
+                            shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            properties:
+                              path:
+                                description: 'path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the NFS export
+                                to be mounted with read-only permissions. Defaults
+                                to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: boolean
+                              server:
+                                description: 'server is the hostname or IP address of
+                                the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                            required:
+                              - path
+                              - server
+                            type: object
+                          persistentVolumeClaim:
+                            description: 'persistentVolumeClaimVolumeSource represents
+                            a reference to a PersistentVolumeClaim in the same namespace.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            properties:
+                              claimName:
+                                description: 'claimName is the name of a PersistentVolumeClaim
+                                in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                type: string
+                              readOnly:
+                                description: readOnly Will force the ReadOnly setting
+                                  in VolumeMounts. Default false.
+                                type: boolean
+                            required:
+                              - claimName
+                            type: object
+                          photonPersistentDisk:
+                            description: photonPersistentDisk represents a PhotonController
+                              persistent disk attached and mounted on kubelets host
+                              machine
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              pdID:
+                                description: pdID is the ID that identifies Photon Controller
+                                  persistent disk
+                                type: string
+                            required:
+                              - pdID
+                            type: object
+                          portworxVolume:
+                            description: portworxVolume represents a portworx volume
+                              attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fSType represents the filesystem type to
+                                  mount Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              volumeID:
+                                description: volumeID uniquely identifies a Portworx
+                                  volume
+                                type: string
+                            required:
+                              - volumeID
+                            type: object
+                          projected:
+                            description: projected items for all in one resources secrets,
+                              configmaps, and downward API
+                            properties:
+                              defaultMode:
+                                description: defaultMode are the mode bits used to set
+                                  permissions on created files by default. Must be an
+                                  octal value between 0000 and 0777 or a decimal value
+                                  between 0 and 511. YAML accepts both octal and decimal
+                                  values, JSON requires decimal values for mode bits.
+                                  Directories within the path are not affected by this
+                                  setting. This might be in conflict with other options
+                                  that affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.
+                                format: int32
+                                type: integer
+                              sources:
+                                description: sources is the list of volume projections
+                                items:
+                                  description: Projection that may be projected along
+                                    with other supported volume types
+                                  properties:
+                                    configMap:
+                                      description: configMap information about the configMap
+                                        data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each key-value
+                                            pair in the Data field of the referenced
+                                            ConfigMap will be projected into the volume
+                                            as a file whose name is the key and content
+                                            is the value. If specified, the listed keys
+                                            will be projected into the specified paths,
+                                            and unlisted keys will not be present. If
+                                            a key is specified which is not present
+                                            in the ConfigMap, the volume setup will
+                                            error unless it is marked optional. Paths
+                                            must be relative and may not contain the
+                                            '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative path
+                                                  of the file to map the key to. May
+                                                  not be an absolute path. May not contain
+                                                  the path element '..'. May not start
+                                                  with the string '..'.
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    downwardAPI:
+                                      description: downwardAPI information about the
+                                        downwardAPI data to project
+                                      properties:
+                                        items:
+                                          description: Items is a list of DownwardAPIVolume
+                                            file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in terms
+                                                      of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field to
+                                                      select in the specified API version.
+                                                    type: string
+                                                required:
+                                                  - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              mode:
+                                                description: 'Optional: mode bits used
+                                                to set permissions on this file, must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                requests.cpu and requests.memory)
+                                                are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                    to select'
+                                                    type: string
+                                                required:
+                                                  - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                              - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    secret:
+                                      description: secret information about the secret
+                                        data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each key-value
+                                            pair in the Data field of the referenced
+                                            Secret will be projected into the volume
+                                            as a file whose name is the key and content
+                                            is the value. If specified, the listed keys
+                                            will be projected into the specified paths,
+                                            and unlisted keys will not be present. If
+                                            a key is specified which is not present
+                                            in the Secret, the volume setup will error
+                                            unless it is marked optional. Paths must
+                                            be relative and may not contain the '..'
+                                            path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative path
+                                                  of the file to map the key to. May
+                                                  not be an absolute path. May not contain
+                                                  the path element '..'. May not start
+                                                  with the string '..'.
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its key must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    serviceAccountToken:
+                                      description: serviceAccountToken is information
+                                        about the serviceAccountToken data to project
+                                      properties:
+                                        audience:
+                                          description: audience is the intended audience
+                                            of the token. A recipient of a token must
+                                            identify itself with an identifier specified
+                                            in the audience of the token, and otherwise
+                                            should reject the token. The audience defaults
+                                            to the identifier of the apiserver.
+                                          type: string
+                                        expirationSeconds:
+                                          description: expirationSeconds is the requested
+                                            duration of validity of the service account
+                                            token. As the token approaches expiration,
+                                            the kubelet volume plugin will proactively
+                                            rotate the service account token. The kubelet
+                                            will start trying to rotate the token if
+                                            the token is older than 80 percent of its
+                                            time to live or if the token is older than
+                                            24 hours.Defaults to 1 hour and must be
+                                            at least 10 minutes.
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          description: path is the path relative to
+                                            the mount point of the file to project the
+                                            token into.
+                                          type: string
+                                      required:
+                                        - path
+                                      type: object
+                                  type: object
+                                type: array
+                            type: object
+                          quobyte:
+                            description: quobyte represents a Quobyte mount on the host
+                              that shares a pod's lifetime
+                            properties:
+                              group:
+                                description: group to map volume access to Default is
+                                  no group
+                                type: string
+                              readOnly:
+                                description: readOnly here will force the Quobyte volume
+                                  to be mounted with read-only permissions. Defaults
+                                  to false.
+                                type: boolean
+                              registry:
+                                description: registry represents a single or multiple
+                                  Quobyte Registry services specified as a string as
+                                  host:port pair (multiple entries are separated with
+                                  commas) which acts as the central registry for volumes
+                                type: string
+                              tenant:
+                                description: tenant owning the given Quobyte volume
+                                  in the Backend Used with dynamically provisioned Quobyte
+                                  volumes, value is set by the plugin
+                                type: string
+                              user:
+                                description: user to map volume access to Defaults to
+                                  serivceaccount user
+                                type: string
+                              volume:
+                                description: volume is a string that references an already
+                                  created Quobyte volume by name.
+                                type: string
+                            required:
+                              - registry
+                              - volume
+                            type: object
+                          rbd:
+                            description: 'rbd represents a Rados Block Device mount
+                            on the host that shares a pod''s lifetime. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                TODO: how do we prevent errors in the filesystem from
+                                compromising the machine'
+                                type: string
+                              image:
+                                description: 'image is the rados image name. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              keyring:
+                                description: 'keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              monitors:
+                                description: 'monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              pool:
+                                description: 'pool is the rados pool name. Default is
+                                rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is name of the authentication
+                                secret for RBDUser. If provided overrides keyring.
+                                Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              user:
+                                description: 'user is the rados user name. Default is
+                                admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                            required:
+                              - image
+                              - monitors
+                            type: object
+                          scaleIO:
+                            description: scaleIO represents a ScaleIO persistent volume
+                              attached and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                type: string
+                              gateway:
+                                description: gateway is the host address of the ScaleIO
+                                  API Gateway.
+                                type: string
+                              protectionDomain:
+                                description: protectionDomain is the name of the ScaleIO
+                                  Protection Domain for the configured storage.
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef references to the secret for
+                                  ScaleIO user and other sensitive information. If this
+                                  is not provided, Login operation will fail.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              sslEnabled:
+                                description: sslEnabled Flag enable/disable SSL communication
+                                  with Gateway, default false
+                                type: boolean
+                              storageMode:
+                                description: storageMode indicates whether the storage
+                                  for a volume should be ThickProvisioned or ThinProvisioned.
+                                  Default is ThinProvisioned.
+                                type: string
+                              storagePool:
+                                description: storagePool is the ScaleIO Storage Pool
+                                  associated with the protection domain.
+                                type: string
+                              system:
+                                description: system is the name of the storage system
+                                  as configured in ScaleIO.
+                                type: string
+                              volumeName:
+                                description: volumeName is the name of a volume already
+                                  created in the ScaleIO system that is associated with
+                                  this volume source.
+                                type: string
+                            required:
+                              - gateway
+                              - secretRef
+                              - system
+                            type: object
+                          secret:
+                            description: 'secret represents a secret that should populate
+                            this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items If unspecified, each key-value pair
+                                  in the Data field of the referenced Secret will be
+                                  projected into the volume as a file whose name is
+                                  the key and content is the value. If specified, the
+                                  listed keys will be projected into the specified paths,
+                                  and unlisted keys will not be present. If a key is
+                                  specified which is not present in the Secret, the
+                                  volume setup will error unless it is marked optional.
+                                  Paths must be relative and may not contain the '..'
+                                  path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within a
+                                    volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                              optional:
+                                description: optional field specify whether the Secret
+                                  or its keys must be defined
+                                type: boolean
+                              secretName:
+                                description: 'secretName is the name of the secret in
+                                the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                type: string
+                            type: object
+                          storageos:
+                            description: storageOS represents a StorageOS volume attached
+                              and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef specifies the secret to use for
+                                  obtaining the StorageOS API credentials.  If not specified,
+                                  default values will be attempted.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              volumeName:
+                                description: volumeName is the human-readable name of
+                                  the StorageOS volume.  Volume names are only unique
+                                  within a namespace.
+                                type: string
+                              volumeNamespace:
+                                description: volumeNamespace specifies the scope of
+                                  the volume within StorageOS.  If no namespace is specified
+                                  then the Pod's namespace will be used.  This allows
+                                  the Kubernetes name scoping to be mirrored within
+                                  StorageOS for tighter integration. Set VolumeName
+                                  to any name to override the default behaviour. Set
+                                  to "default" if you are not using namespaces within
+                                  StorageOS. Namespaces that do not pre-exist within
+                                  StorageOS will be created.
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            description: vsphereVolume represents a vSphere volume attached
+                              and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fsType is filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              storagePolicyID:
+                                description: storagePolicyID is the storage Policy Based
+                                  Management (SPBM) profile ID associated with the StoragePolicyName.
+                                type: string
+                              storagePolicyName:
+                                description: storagePolicyName is the storage Policy
+                                  Based Management (SPBM) profile name.
+                                type: string
+                              volumePath:
+                                description: volumePath is the path that identifies
+                                  vSphere volume vmdk
+                                type: string
+                            required:
+                              - volumePath
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    logLevel:
+                      description: LogLevel sets the log level for Envoy. Allowed values
+                        are "trace", "debug", "info", "warn", "error", "critical", "off".
+                      type: string
+                    networkPublishing:
+                      description: NetworkPublishing defines how to expose Envoy to
+                        a network.
+                      properties:
+                        externalTrafficPolicy:
+                          description: "ExternalTrafficPolicy describes how nodes distribute
+                          service traffic they receive on one of the Service's \"externally-facing\"
+                          addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
+                          \n If unset, defaults to \"Local\"."
+                          type: string
+                        ipFamilyPolicy:
+                          description: IPFamilyPolicy represents the dual-stack-ness
+                            requested or required by this Service. If there is no value
+                            provided, then this field will be set to SingleStack. Services
+                            can be "SingleStack" (a single IP family), "PreferDualStack"
+                            (two IP families on dual-stack configured clusters or a
+                            single IP family on single-stack clusters), or "RequireDualStack"
+                            (two IP families on dual-stack configured clusters, otherwise
+                            fail).
+                          type: string
+                        serviceAnnotations:
+                          additionalProperties:
+                            type: string
+                          description: ServiceAnnotations is the annotations to add
+                            to the provisioned Envoy service.
+                          type: object
+                        type:
+                          description: "NetworkPublishingType is the type of publishing
+                          strategy to use. Valid values are: \n * LoadBalancerService
+                          \n In this configuration, network endpoints for Envoy use
+                          container networking. A Kubernetes LoadBalancer Service
+                          is created to publish Envoy network endpoints. \n See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+                          \n * NodePortService \n Publishes Envoy network endpoints
+                          using a Kubernetes NodePort Service. \n In this configuration,
+                          Envoy network endpoints use container networking. A Kubernetes
+                          NodePort Service is created to publish the network endpoints.
+                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+                          \n NOTE: When provisioning an Envoy `NodePortService`, use
+                          Gateway Listeners' port numbers to populate the Service's
+                          node port values, there's no way to auto-allocate them.
+                          \n See: https://github.com/projectcontour/contour/issues/4499
+                          \n * ClusterIPService \n Publishes Envoy network endpoints
+                          using a Kubernetes ClusterIP Service. \n In this configuration,
+                          Envoy network endpoints use container networking. A Kubernetes
+                          ClusterIP Service is created to publish the network endpoints.
+                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                          \n If unset, defaults to LoadBalancerService."
+                          type: string
+                      type: object
+                    nodePlacement:
+                      description: NodePlacement describes node scheduling configuration
+                        of Envoy pods.
+                      properties:
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          description: "NodeSelector is the simplest recommended form
+                          of node selection constraint and specifies a map of key-value
+                          pairs. For the pod to be eligible to run on a node, the
+                          node must have each of the indicated key-value pairs as
+                          labels (it can have additional labels as well). \n If unset,
+                          the pod(s) will be scheduled to any available node."
+                          type: object
+                        tolerations:
+                          description: "Tolerations work with taints to ensure that
+                          pods are not scheduled onto inappropriate nodes. One or
+                          more taints are applied to a node; this marks that the node
+                          should not accept any pods that do not tolerate the taints.
+                          \n The default is an empty list. \n See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                          for additional details."
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect> using
+                              the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match.
+                                  Empty means match all taint effects. When specified,
+                                  allowed values are NoSchedule, PreferNoSchedule and
+                                  NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If the
+                                  key is empty, operator must be Exists; this combination
+                                  means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints of
+                                  a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect NoExecute,
+                                  otherwise this field is ignored) tolerates the taint.
+                                  By default, it is not set, which means tolerate the
+                                  taint forever (do not evict). Zero and negative values
+                                  will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value should
+                                  be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    podAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: PodAnnotations defines annotations to add to the
+                        Envoy pods. the annotations for Prometheus will be appended
+                        or overwritten with predefined value.
+                      type: object
+                    replicas:
+                      description: "Deprecated: Use `DeploymentSettings.Replicas` instead.
+                      \n Replicas is the desired number of Envoy replicas. If WorkloadType
+                      is not \"Deployment\", this field is ignored. Otherwise, if
+                      unset, defaults to 2. \n if both `DeploymentSettings.Replicas`
+                      and this one is set, use `DeploymentSettings.Replicas`."
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    resources:
+                      description: 'Compute Resources required by envoy container. Cannot
+                      be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      properties:
+                        claims:
+                          description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: Name must match the name of one entry in
+                                  pod.spec.resourceClaims of the Pod where this field
+                                  is used. It makes that resource available inside a
+                                  container.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    workloadType:
+                      description: WorkloadType is the type of workload to install Envoy
+                        as. Choices are DaemonSet and Deployment. If unset, defaults
+                        to DaemonSet.
+                      type: string
+                  type: object
+                resourceLabels:
+                  additionalProperties:
+                    type: string
+                  description: ResourceLabels is a set of labels to add to the provisioned
+                    Contour resources.
+                  type: object
+                runtimeSettings:
+                  description: RuntimeSettings is a ContourConfiguration spec to be
+                    used when provisioning a Contour instance that will influence aspects
+                    of the Contour instance's runtime behavior.
+                  properties:
+                    debug:
+                      description: Debug contains parameters to enable debug logging
+                        and debug interfaces inside Contour.
+                      properties:
+                        address:
+                          description: "Defines the Contour debug address interface.
+                          \n Contour's default is \"127.0.0.1\"."
+                          type: string
+                        port:
+                          description: "Defines the Contour debug address port. \n Contour's
+                          default is 6060."
+                          type: integer
+                      type: object
+                    enableExternalNameService:
+                      description: "EnableExternalNameService allows processing of ExternalNameServices
+                      \n Contour's default is false for security reasons."
+                      type: boolean
+                    envoy:
+                      description: Envoy contains parameters for Envoy as well as how
+                        to optionally configure a managed Envoy fleet.
+                      properties:
+                        clientCertificate:
+                          description: ClientCertificate defines the namespace/name
+                            of the Kubernetes secret containing the client certificate
+                            and private key to be used when establishing TLS connection
+                            to upstream cluster.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                            - name
+                            - namespace
+                          type: object
+                        cluster:
+                          description: Cluster holds various configurable Envoy cluster
+                            values that can be set in the config file.
+                          properties:
+                            dnsLookupFamily:
+                              description: "DNSLookupFamily defines how external names
+                              are looked up When configured as V4, the DNS resolver
+                              will only perform a lookup for addresses in the IPv4
+                              family. If V6 is configured, the DNS resolver will only
+                              perform a lookup for addresses in the IPv6 family. If
+                              AUTO is configured, the DNS resolver will first perform
+                              a lookup for addresses in the IPv6 family and fallback
+                              to a lookup for addresses in the IPv4 family. If ALL
+                              is specified, the DNS resolver will perform a lookup
+                              for both IPv4 and IPv6 families, and return all resolved
+                              addresses. When this is used, Happy Eyeballs will be
+                              enabled for upstream connections. Refer to Happy Eyeballs
+                              Support for more information. Note: This only applies
+                              to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                              for more information. \n Values: `auto` (default), `v4`,
+                              `v6`, `all`. \n Other values will produce an error."
+                              type: string
+                            maxRequestsPerConnection:
+                              description: Defines the maximum requests for upstream
+                                connections. If not specified, there is no limit. see
+                                https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions
+                                for more information.
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            per-connection-buffer-limit-bytes:
+                              description: Defines the soft limit on size of the cluster’s
+                                new connection read and write buffers in bytes. If unspecified,
+                                an implementation defined default is applied (1MiB).
+                                see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-per-connection-buffer-limit-bytes
+                                for more information.
+                              format: int32
+                              minimum: 1
+                              type: integer
+                          type: object
+                        defaultHTTPVersions:
+                          description: "DefaultHTTPVersions defines the default set
+                          of HTTPS versions the proxy should accept. HTTP versions
+                          are strings of the form \"HTTP/xx\". Supported versions
+                          are \"HTTP/1.1\" and \"HTTP/2\". \n Values: `HTTP/1.1`,
+                          `HTTP/2` (default: both). \n Other values will produce an
+                          error."
+                          items:
+                            description: HTTPVersionType is the name of a supported
+                              HTTP version.
+                            type: string
+                          type: array
+                        health:
+                          description: "Health defines the endpoint Envoy uses to serve
+                          health checks. \n Contour's default is { address: \"0.0.0.0\",
+                          port: 8002 }."
+                          properties:
+                            address:
+                              description: Defines the health address interface.
+                              minLength: 1
+                              type: string
+                            port:
+                              description: Defines the health port.
+                              type: integer
+                          type: object
+                        http:
+                          description: "Defines the HTTP Listener for Envoy. \n Contour's
+                          default is { address: \"0.0.0.0\", port: 8080, accessLog:
+                          \"/dev/stdout\" }."
+                          properties:
+                            accessLog:
+                              description: AccessLog defines where Envoy logs are outputted
+                                for this listener.
+                              type: string
+                            address:
+                              description: Defines an Envoy Listener Address.
+                              minLength: 1
+                              type: string
+                            port:
+                              description: Defines an Envoy listener Port.
+                              type: integer
+                          type: object
+                        https:
+                          description: "Defines the HTTPS Listener for Envoy. \n Contour's
+                          default is { address: \"0.0.0.0\", port: 8443, accessLog:
+                          \"/dev/stdout\" }."
+                          properties:
+                            accessLog:
+                              description: AccessLog defines where Envoy logs are outputted
+                                for this listener.
+                              type: string
+                            address:
+                              description: Defines an Envoy Listener Address.
+                              minLength: 1
+                              type: string
+                            port:
+                              description: Defines an Envoy listener Port.
+                              type: integer
+                          type: object
+                        listener:
+                          description: Listener hold various configurable Envoy listener
+                            values.
+                          properties:
+                            connectionBalancer:
+                              description: "ConnectionBalancer. If the value is exact,
+                              the listener will use the exact connection balancer
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
+                              for more information. \n Values: (empty string): use
+                              the default ConnectionBalancer, `exact`: use the Exact
+                              ConnectionBalancer. \n Other values will produce an
+                              error."
+                              type: string
+                            disableAllowChunkedLength:
+                              description: "DisableAllowChunkedLength disables the RFC-compliant
+                              Envoy behavior to strip the \"Content-Length\" header
+                              if \"Transfer-Encoding: chunked\" is also set. This
+                              is an emergency off-switch to revert back to Envoy's
+                              default behavior in case of failures. Please file an
+                              issue if failures are encountered. See: https://github.com/projectcontour/contour/issues/3221
+                              \n Contour's default is false."
+                              type: boolean
+                            disableMergeSlashes:
+                              description: "DisableMergeSlashes disables Envoy's non-standard
+                              merge_slashes path transformation option which strips
+                              duplicate slashes from request URL paths. \n Contour's
+                              default is false."
+                              type: boolean
+                            maxRequestsPerConnection:
+                              description: Defines the maximum requests for downstream
+                                connections. If not specified, there is no limit. see
+                                https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions
+                                for more information.
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            per-connection-buffer-limit-bytes:
+                              description: Defines the soft limit on size of the listener’s
+                                new connection read and write buffers in bytes. If unspecified,
+                                an implementation defined default is applied (1MiB).
+                                see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto#envoy-v3-api-field-config-listener-v3-listener-per-connection-buffer-limit-bytes
+                                for more information.
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            serverHeaderTransformation:
+                              description: "Defines the action to be applied to the
+                              Server header on the response path. When configured
+                              as overwrite, overwrites any Server header with \"envoy\".
+                              When configured as append_if_absent, if a Server header
+                              is present, pass it through, otherwise set it to \"envoy\".
+                              When configured as pass_through, pass through the value
+                              of the Server header, and do not append a header if
+                              none is present. \n Values: `overwrite` (default), `append_if_absent`,
+                              `pass_through` \n Other values will produce an error.
+                              Contour's default is overwrite."
+                              type: string
+                            tls:
+                              description: TLS holds various configurable Envoy TLS
+                                listener values.
+                              properties:
+                                cipherSuites:
+                                  description: "CipherSuites defines the TLS ciphers
+                                  to be supported by Envoy TLS listeners when negotiating
+                                  TLS 1.2. Ciphers are validated against the set that
+                                  Envoy supports by default. This parameter should
+                                  only be used by advanced users. Note that these
+                                  will be ignored when TLS 1.3 is in use. \n This
+                                  field is optional; when it is undefined, a Contour-managed
+                                  ciphersuite list will be used, which may be updated
+                                  to keep it secure. \n Contour's default list is:
+                                  - \"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]\"
+                                  - \"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]\"
+                                  - \"ECDHE-ECDSA-AES256-GCM-SHA384\" - \"ECDHE-RSA-AES256-GCM-SHA384\"
+                                  \n Ciphers provided are validated against the following
+                                  list: - \"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]\"
+                                  - \"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]\"
+                                  - \"ECDHE-ECDSA-AES128-GCM-SHA256\" - \"ECDHE-RSA-AES128-GCM-SHA256\"
+                                  - \"ECDHE-ECDSA-AES128-SHA\" - \"ECDHE-RSA-AES128-SHA\"
+                                  - \"AES128-GCM-SHA256\" - \"AES128-SHA\" - \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+                                  - \"ECDHE-RSA-AES256-GCM-SHA384\" - \"ECDHE-ECDSA-AES256-SHA\"
+                                  - \"ECDHE-RSA-AES256-SHA\" - \"AES256-GCM-SHA384\"
+                                  - \"AES256-SHA\" \n Contour recommends leaving this
+                                  undefined unless you are sure you must. \n See:
+                                  https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
+                                  Note: This list is a superset of what is valid for
+                                  stock Envoy builds and those using BoringSSL FIPS."
+                                  items:
+                                    type: string
+                                  type: array
+                                minimumProtocolVersion:
+                                  description: "MinimumProtocolVersion is the minimum
+                                  TLS version this vhost should negotiate. \n Values:
+                                  `1.2` (default), `1.3`. \n Other values will produce
+                                  an error."
+                                  type: string
+                              type: object
+                            useProxyProtocol:
+                              description: "Use PROXY protocol for all listeners. \n
+                              Contour's default is false."
+                              type: boolean
+                          type: object
+                        logging:
+                          description: Logging defines how Envoy's logs can be configured.
+                          properties:
+                            accessLogFormat:
+                              description: "AccessLogFormat sets the global access log
+                              format. \n Values: `envoy` (default), `json`. \n Other
+                              values will produce an error."
+                              type: string
+                            accessLogFormatString:
+                              description: AccessLogFormatString sets the access log
+                                format when format is set to `envoy`. When empty, Envoy's
+                                default format is used.
+                              type: string
+                            accessLogJSONFields:
+                              description: AccessLogJSONFields sets the fields that
+                                JSON logging will output when AccessLogFormat is json.
+                              items:
+                                type: string
+                              type: array
+                            accessLogLevel:
+                              description: "AccessLogLevel sets the verbosity level
+                              of the access log. \n Values: `info` (default, all requests
+                              are logged), `error` (all non-success requests, i.e.
+                              300+ response code, are logged), `critical` (all 5xx
+                              requests are logged) and `disabled`. \n Other values
+                              will produce an error."
+                              type: string
+                          type: object
+                        metrics:
+                          description: "Metrics defines the endpoint Envoy uses to serve
+                          metrics. \n Contour's default is { address: \"0.0.0.0\",
+                          port: 8002 }."
+                          properties:
+                            address:
+                              description: Defines the metrics address interface.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            port:
+                              description: Defines the metrics port.
+                              type: integer
+                            tls:
+                              description: TLS holds TLS file config details. Metrics
+                                and health endpoints cannot have same port number when
+                                metrics is served over HTTPS.
+                              properties:
+                                caFile:
+                                  description: CA filename.
+                                  type: string
+                                certFile:
+                                  description: Client certificate filename.
+                                  type: string
+                                keyFile:
+                                  description: Client key filename.
+                                  type: string
+                              type: object
+                          type: object
+                        network:
+                          description: Network holds various configurable Envoy network
+                            values.
+                          properties:
+                            adminPort:
+                              description: "Configure the port used to access the Envoy
+                              Admin interface. If configured to port \"0\" then the
+                              admin interface is disabled. \n Contour's default is
+                              9001."
+                              type: integer
+                            numTrustedHops:
+                              description: "XffNumTrustedHops defines the number of
+                              additional ingress proxy hops from the right side of
+                              the x-forwarded-for HTTP header to trust when determining
+                              the origin client’s IP address. \n See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
+                              for more information. \n Contour's default is 0."
+                              format: int32
+                              type: integer
+                          type: object
+                        service:
+                          description: "Service holds Envoy service parameters for setting
+                          Ingress status. \n Contour's default is { namespace: \"projectcontour\",
+                          name: \"envoy\" }."
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                            - name
+                            - namespace
+                          type: object
+                        timeouts:
+                          description: Timeouts holds various configurable timeouts
+                            that can be set in the config file.
+                          properties:
+                            connectTimeout:
+                              description: "ConnectTimeout defines how long the proxy
+                              should wait when establishing connection to upstream
+                              service. If not set, a default value of 2 seconds will
+                              be used. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-connect-timeout
+                              for more information."
+                              type: string
+                            connectionIdleTimeout:
+                              description: "ConnectionIdleTimeout defines how long the
+                              proxy should wait while there are no active requests
+                              (for HTTP/1.1) or streams (for HTTP/2) before terminating
+                              an HTTP connection. Set to \"infinity\" to disable the
+                              timeout entirely. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
+                              for more information."
+                              type: string
+                            connectionShutdownGracePeriod:
+                              description: "ConnectionShutdownGracePeriod defines how
+                              long the proxy will wait between sending an initial
+                              GOAWAY frame and a second, final GOAWAY frame when terminating
+                              an HTTP/2 connection. During this grace period, the
+                              proxy will continue to respond to new streams. After
+                              the final GOAWAY frame has been sent, the proxy will
+                              refuse new streams. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-drain-timeout
+                              for more information."
+                              type: string
+                            delayedCloseTimeout:
+                              description: "DelayedCloseTimeout defines how long envoy
+                              will wait, once connection close processing has been
+                              initiated, for the downstream peer to close the connection
+                              before Envoy closes the socket associated with the connection.
+                              \n Setting this timeout to 'infinity' will disable it,
+                              equivalent to setting it to '0' in Envoy. Leaving it
+                              unset will result in the Envoy default value being used.
+                              \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-delayed-close-timeout
+                              for more information."
+                              type: string
+                            maxConnectionDuration:
+                              description: "MaxConnectionDuration defines the maximum
+                              period of time after an HTTP connection has been established
+                              from the client to the proxy before it is closed by
+                              the proxy, regardless of whether there has been activity
+                              or not. Omit or set to \"infinity\" for no max duration.
+                              \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration
+                              for more information."
+                              type: string
+                            requestTimeout:
+                              description: "RequestTimeout sets the client request timeout
+                              globally for Contour. Note that this is a timeout for
+                              the entire request, not an idle timeout. Omit or set
+                              to \"infinity\" to disable the timeout entirely. \n
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-request-timeout
+                              for more information."
+                              type: string
+                            streamIdleTimeout:
+                              description: "StreamIdleTimeout defines how long the proxy
+                              should wait while there is no request activity (for
+                              HTTP/1.1) or stream activity (for HTTP/2) before terminating
+                              the HTTP request or stream. Set to \"infinity\" to disable
+                              the timeout entirely. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
+                              for more information."
+                              type: string
+                          type: object
+                      type: object
+                    gateway:
+                      description: Gateway contains parameters for the gateway-api Gateway
+                        that Contour is configured to serve traffic.
+                      properties:
+                        controllerName:
+                          description: ControllerName is used to determine whether Contour
+                            should reconcile a GatewayClass. The string takes the form
+                            of "projectcontour.io/<namespace>/contour". If unset, the
+                            gatewayclass controller will not be started. Exactly one
+                            of ControllerName or GatewayRef must be set.
+                          type: string
+                        gatewayRef:
+                          description: GatewayRef defines a specific Gateway that this
+                            Contour instance corresponds to. If set, Contour will reconcile
+                            only this gateway, and will not reconcile any gateway classes.
+                            Exactly one of ControllerName or GatewayRef must be set.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                            - name
+                            - namespace
+                          type: object
+                      type: object
+                    globalExtAuth:
+                      description: GlobalExternalAuthorization allows envoys external
+                        authorization filter to be enabled for all virtual hosts.
+                      properties:
+                        authPolicy:
+                          description: AuthPolicy sets a default authorization policy
+                            for client requests. This policy will be used unless overridden
+                            by individual routes.
+                          properties:
+                            context:
+                              additionalProperties:
+                                type: string
+                              description: Context is a set of key/value pairs that
+                                are sent to the authentication server in the check request.
+                                If a context is provided at an enclosing scope, the
+                                entries are merged such that the inner scope overrides
+                                matching keys from the outer scope.
+                              type: object
+                            disabled:
+                              description: When true, this field disables client request
+                                authentication for the scope of the policy.
+                              type: boolean
+                          type: object
+                        extensionRef:
+                          description: ExtensionServiceRef specifies the extension resource
+                            that will authorize client requests.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent. If this field
+                                is not specified, the default "projectcontour.io/v1alpha1"
+                                will be used
+                              minLength: 1
+                              type: string
+                            name:
+                              description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: "Namespace of the referent. If this field
+                              is not specifies, the namespace of the resource that
+                              targets the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                              minLength: 1
+                              type: string
+                          type: object
+                        failOpen:
+                          description: If FailOpen is true, the client request is forwarded
+                            to the upstream service even if the authorization server
+                            fails to respond. This field should not be set in most cases.
+                            It is intended for use only while migrating applications
+                            from internal authorization to Contour external authorization.
+                          type: boolean
+                        responseTimeout:
+                          description: ResponseTimeout configures maximum time to wait
+                            for a check response from the authorization server. Timeout
+                            durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                            Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+                            "h". The string "infinity" is also a valid input and specifies
+                            no timeout.
+                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                          type: string
+                        withRequestBody:
+                          description: WithRequestBody specifies configuration for sending
+                            the client request's body to authorization server.
+                          properties:
+                            allowPartialMessage:
+                              description: If AllowPartialMessage is true, then Envoy
+                                will buffer the body until MaxRequestBytes are reached.
+                              type: boolean
+                            maxRequestBytes:
+                              default: 1024
+                              description: MaxRequestBytes sets the maximum size of
+                                message body ExtAuthz filter will hold in-memory.
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            packAsBytes:
+                              description: If PackAsBytes is true, the body sent to
+                                Authorization Server is in raw bytes.
+                              type: boolean
+                          type: object
+                      type: object
+                    health:
+                      description: "Health defines the endpoints Contour uses to serve
+                      health checks. \n Contour's default is { address: \"0.0.0.0\",
+                      port: 8000 }."
+                      properties:
+                        address:
+                          description: Defines the health address interface.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Defines the health port.
+                          type: integer
+                      type: object
+                    httpproxy:
+                      description: HTTPProxy defines parameters on HTTPProxy.
+                      properties:
+                        disablePermitInsecure:
+                          description: "DisablePermitInsecure disables the use of the
+                          permitInsecure field in HTTPProxy. \n Contour's default
+                          is false."
+                          type: boolean
+                        fallbackCertificate:
+                          description: FallbackCertificate defines the namespace/name
+                            of the Kubernetes secret to use as fallback when a non-SNI
+                            request is received.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                            - name
+                            - namespace
+                          type: object
+                        rootNamespaces:
+                          description: Restrict Contour to searching these namespaces
+                            for root ingress routes.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    ingress:
+                      description: Ingress contains parameters for ingress options.
+                      properties:
+                        classNames:
+                          description: Ingress Class Names Contour should use.
+                          items:
+                            type: string
+                          type: array
+                        statusAddress:
+                          description: Address to set in Ingress object status.
+                          type: string
+                      type: object
+                    metrics:
+                      description: "Metrics defines the endpoint Contour uses to serve
+                      metrics. \n Contour's default is { address: \"0.0.0.0\", port:
+                      8000 }."
+                      properties:
+                        address:
+                          description: Defines the metrics address interface.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Defines the metrics port.
+                          type: integer
+                        tls:
+                          description: TLS holds TLS file config details. Metrics and
+                            health endpoints cannot have same port number when metrics
+                            is served over HTTPS.
+                          properties:
+                            caFile:
+                              description: CA filename.
+                              type: string
+                            certFile:
+                              description: Client certificate filename.
+                              type: string
+                            keyFile:
+                              description: Client key filename.
+                              type: string
+                          type: object
+                      type: object
+                    policy:
+                      description: Policy specifies default policy applied if not overridden
+                        by the user
+                      properties:
+                        applyToIngress:
+                          description: "ApplyToIngress determines if the Policies will
+                          apply to ingress objects \n Contour's default is false."
+                          type: boolean
+                        requestHeaders:
+                          description: RequestHeadersPolicy defines the request headers
+                            set/removed on all routes
+                          properties:
+                            remove:
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        responseHeaders:
+                          description: ResponseHeadersPolicy defines the response headers
+                            set/removed on all routes
+                          properties:
+                            remove:
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                      type: object
+                    rateLimitService:
+                      description: RateLimitService optionally holds properties of the
+                        Rate Limit Service to be used for global rate limiting.
+                      properties:
+                        defaultGlobalRateLimitPolicy:
+                          description: DefaultGlobalRateLimitPolicy allows setting a
+                            default global rate limit policy for every HTTPProxy. HTTPProxy
+                            can overwrite this configuration.
+                          properties:
+                            descriptors:
+                              description: Descriptors defines the list of descriptors
+                                that will be generated and sent to the rate limit service.
+                                Each descriptor contains 1+ key-value pair entries.
+                              items:
+                                description: RateLimitDescriptor defines a list of key-value
+                                  pair generators.
+                                properties:
+                                  entries:
+                                    description: Entries is the list of key-value pair
+                                      generators.
+                                    items:
+                                      description: RateLimitDescriptorEntry is a key-value
+                                        pair generator. Exactly one field on this struct
+                                        must be non-nil.
+                                      properties:
+                                        genericKey:
+                                          description: GenericKey defines a descriptor
+                                            entry with a static key and value.
+                                          properties:
+                                            key:
+                                              description: Key defines the key of the
+                                                descriptor entry. If not set, the key
+                                                is set to "generic_key".
+                                              type: string
+                                            value:
+                                              description: Value defines the value of
+                                                the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                        remoteAddress:
+                                          description: RemoteAddress defines a descriptor
+                                            entry with a key of "remote_address" and
+                                            a value equal to the client's IP address
+                                            (from x-forwarded-for).
+                                          type: object
+                                        requestHeader:
+                                          description: RequestHeader defines a descriptor
+                                            entry that's populated only if a given header
+                                            is present on the request. The descriptor
+                                            key is static, and the descriptor value
+                                            is equal to the value of the header.
+                                          properties:
+                                            descriptorKey:
+                                              description: DescriptorKey defines the
+                                                key to use on the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                            headerName:
+                                              description: HeaderName defines the name
+                                                of the header to look for on the request.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                        requestHeaderValueMatch:
+                                          description: RequestHeaderValueMatch defines
+                                            a descriptor entry that's populated if the
+                                            request's headers match a set of 1+ match
+                                            criteria. The descriptor key is "header_match",
+                                            and the descriptor value is static.
+                                          properties:
+                                            expectMatch:
+                                              default: true
+                                              description: ExpectMatch defines whether
+                                                the request must positively match the
+                                                match criteria in order to generate
+                                                a descriptor entry (i.e. true), or not
+                                                match the match criteria in order to
+                                                generate a descriptor entry (i.e. false).
+                                                The default is true.
+                                              type: boolean
+                                            headers:
+                                              description: Headers is a list of 1+ match
+                                                criteria to apply against the request
+                                                to determine whether to populate the
+                                                descriptor entry or not.
+                                              items:
+                                                description: HeaderMatchCondition specifies
+                                                  how to conditionally match against
+                                                  HTTP headers. The Name field is required,
+                                                  but only one of the remaining fields
+                                                  should be be provided.
+                                                properties:
+                                                  contains:
+                                                    description: Contains specifies
+                                                      a substring that must be present
+                                                      in the header value.
+                                                    type: string
+                                                  exact:
+                                                    description: Exact specifies a string
+                                                      that the header value must be
+                                                      equal to.
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name of
+                                                      the header to match against. Name
+                                                      is required. Header names are
+                                                      case insensitive.
+                                                    type: string
+                                                  notcontains:
+                                                    description: NotContains specifies
+                                                      a substring that must not be present
+                                                      in the header value.
+                                                    type: string
+                                                  notexact:
+                                                    description: NoExact specifies a
+                                                      string that the header value must
+                                                      not be equal to. The condition
+                                                      is true if the header has any
+                                                      other value.
+                                                    type: string
+                                                  notpresent:
+                                                    description: NotPresent specifies
+                                                      that condition is true when the
+                                                      named header is not present. Note
+                                                      that setting NotPresent to false
+                                                      does not make the condition true
+                                                      if the named header is present.
+                                                    type: boolean
+                                                  present:
+                                                    description: Present specifies that
+                                                      condition is true when the named
+                                                      header is present, regardless
+                                                      of its value. Note that setting
+                                                      Present to false does not make
+                                                      the condition true if the named
+                                                      header is absent.
+                                                    type: boolean
+                                                  regex:
+                                                    description: Regex specifies a regular
+                                                      expression pattern that must match
+                                                      the header value.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              minItems: 1
+                                              type: array
+                                            value:
+                                              description: Value defines the value of
+                                                the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                      type: object
+                                    minItems: 1
+                                    type: array
+                                type: object
+                              minItems: 1
+                              type: array
+                            disabled:
+                              description: Disabled configures the HTTPProxy to not
+                                use the default global rate limit policy defined by
+                                the Contour configuration.
+                              type: boolean
+                          type: object
+                        domain:
+                          description: Domain is passed to the Rate Limit Service.
+                          type: string
+                        enableResourceExhaustedCode:
+                          description: EnableResourceExhaustedCode enables translating
+                            error code 429 to grpc code RESOURCE_EXHAUSTED. When disabled
+                            it's translated to UNAVAILABLE
+                          type: boolean
+                        enableXRateLimitHeaders:
+                          description: "EnableXRateLimitHeaders defines whether to include
+                          the X-RateLimit headers X-RateLimit-Limit, X-RateLimit-Remaining,
+                          and X-RateLimit-Reset (as defined by the IETF Internet-Draft
+                          linked below), on responses to clients when the Rate Limit
+                          Service is consulted for a request. \n ref. https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html"
+                          type: boolean
+                        extensionService:
+                          description: ExtensionService identifies the extension service
+                            defining the RLS.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                            - name
+                            - namespace
+                          type: object
+                        failOpen:
+                          description: FailOpen defines whether to allow requests to
+                            proceed when the Rate Limit Service fails to respond with
+                            a valid rate limit decision within the timeout defined on
+                            the extension service.
+                          type: boolean
+                      required:
+                        - extensionService
+                      type: object
+                    tracing:
+                      description: Tracing defines properties for exporting trace data
+                        to OpenTelemetry.
+                      properties:
+                        customTags:
+                          description: CustomTags defines a list of custom tags with
+                            unique tag name.
+                          items:
+                            description: CustomTag defines custom tags with unique tag
+                              name to create tags for the active span.
+                            properties:
+                              literal:
+                                description: Literal is a static custom tag value. Precisely
+                                  one of Literal, RequestHeaderName must be set.
+                                type: string
+                              requestHeaderName:
+                                description: RequestHeaderName indicates which request
+                                  header the label value is obtained from. Precisely
+                                  one of Literal, RequestHeaderName must be set.
+                                type: string
+                              tagName:
+                                description: TagName is the unique name of the custom
+                                  tag.
+                                type: string
+                            required:
+                              - tagName
+                            type: object
+                          type: array
+                        extensionService:
+                          description: ExtensionService identifies the extension service
+                            defining the otel-collector.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                            - name
+                            - namespace
+                          type: object
+                        includePodDetail:
+                          description: 'IncludePodDetail defines a flag. If it is true,
+                          contour will add the pod name and namespace to the span
+                          of the trace. the default is true. Note: The Envoy pods
+                          MUST have the HOSTNAME and CONTOUR_NAMESPACE environment
+                          variables set for this to work properly.'
+                          type: boolean
+                        maxPathTagLength:
+                          description: MaxPathTagLength defines maximum length of the
+                            request path to extract and include in the HttpUrl tag.
+                            contour's default is 256.
+                          format: int32
+                          type: integer
+                        overallSampling:
+                          description: OverallSampling defines the sampling rate of
+                            trace data. contour's default is 100.
+                          type: string
+                        serviceName:
+                          description: ServiceName defines the name for the service.
+                            contour's default is contour.
+                          type: string
+                      required:
+                        - extensionService
+                      type: object
+                    xdsServer:
+                      description: XDSServer contains parameters for the xDS server.
+                      properties:
+                        address:
+                          description: "Defines the xDS gRPC API address which Contour
+                          will serve. \n Contour's default is \"0.0.0.0\"."
+                          minLength: 1
+                          type: string
+                        port:
+                          description: "Defines the xDS gRPC API port which Contour
+                          will serve. \n Contour's default is 8001."
+                          type: integer
+                        tls:
+                          description: "TLS holds TLS file config details. \n Contour's
+                          default is { caFile: \"/certs/ca.crt\", certFile: \"/certs/tls.cert\",
+                          keyFile: \"/certs/tls.key\", insecure: false }."
+                          properties:
+                            caFile:
+                              description: CA filename.
+                              type: string
+                            certFile:
+                              description: Client certificate filename.
+                              type: string
+                            insecure:
+                              description: Allow serving the xDS gRPC API without TLS.
+                              type: boolean
+                            keyFile:
+                              description: Client key filename.
+                              type: string
+                          type: object
+                        type:
+                          description: "Defines the XDSServer to use for `contour serve`.
+                          \n Values: `contour` (default), `envoy`. \n Other values
+                          will produce an error."
+                          type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: ContourDeploymentStatus defines the observed state of a ContourDeployment
+                resource.
+              properties:
+                conditions:
+                  description: Conditions describe the current conditions of the ContourDeployment
+                    resource.
+                  items:
+                    description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition
+                          transitioned from one status to another. This should be when
+                          the underlying condition changed.  If that is not known, then
+                          using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating
+                          details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if .metadata.generation
+                          is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition. Producers
+                          of specific condition types may define expected values and
+                          meanings for this field, and whether the values are considered
+                          a guaranteed API. The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          --- Many .condition.type values are consistent across resources
+                          like Available, but because arbitrary conditions can be useful
+                          (see .node.status.conditions), the ability to deconflict is
+                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: extensionservices.projectcontour.io
+spec:
+  preserveUnknownFields: false
+  group: projectcontour.io
+  names:
+    kind: ExtensionService
+    listKind: ExtensionServiceList
+    plural: extensionservices
+    shortNames:
+      - extensionservice
+      - extensionservices
+    singular: extensionservice
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ExtensionService is the schema for the Contour extension services
+            API. An ExtensionService resource binds a network service to the Contour
+            API so that Contour API features can be implemented by collaborating components.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ExtensionServiceSpec defines the desired state of an ExtensionService
+                resource.
+              properties:
+                loadBalancerPolicy:
+                  description: The policy for load balancing GRPC service requests.
+                    Note that the `Cookie` and `RequestHash` load balancing strategies
+                    cannot be used here.
+                  properties:
+                    requestHashPolicies:
+                      description: RequestHashPolicies contains a list of hash policies
+                        to apply when the `RequestHash` load balancing strategy is chosen.
+                        If an element of the supplied list of hash policies is invalid,
+                        it will be ignored. If the list of hash policies is empty after
+                        validation, the load balancing strategy will fall back to the
+                        default `RoundRobin`.
+                      items:
+                        description: RequestHashPolicy contains configuration for an
+                          individual hash policy on a request attribute.
+                        properties:
+                          hashSourceIP:
+                            description: HashSourceIP should be set to true when request
+                              source IP hash based load balancing is desired. It must
+                              be the only hash option field set, otherwise this request
+                              hash policy object will be ignored.
+                            type: boolean
+                          headerHashOptions:
+                            description: HeaderHashOptions should be set when request
+                              header hash based load balancing is desired. It must be
+                              the only hash option field set, otherwise this request
+                              hash policy object will be ignored.
+                            properties:
+                              headerName:
+                                description: HeaderName is the name of the HTTP request
+                                  header that will be used to calculate the hash key.
+                                  If the header specified is not present on a request,
+                                  no hash will be produced.
+                                minLength: 1
+                                type: string
+                            type: object
+                          queryParameterHashOptions:
+                            description: QueryParameterHashOptions should be set when
+                              request query parameter hash based load balancing is desired.
+                              It must be the only hash option field set, otherwise this
+                              request hash policy object will be ignored.
+                            properties:
+                              parameterName:
+                                description: ParameterName is the name of the HTTP request
+                                  query parameter that will be used to calculate the
+                                  hash key. If the query parameter specified is not
+                                  present on a request, no hash will be produced.
+                                minLength: 1
+                                type: string
+                            type: object
+                          terminal:
+                            description: Terminal is a flag that allows for short-circuiting
+                              computing of a hash for a given request. If set to true,
+                              and the request attribute specified in the attribute hash
+                              options is present, no further hash policies will be used
+                              to calculate a hash for the request.
+                            type: boolean
+                        type: object
+                      type: array
+                    strategy:
+                      description: Strategy specifies the policy used to balance requests
+                        across the pool of backend pods. Valid policy names are `Random`,
+                        `RoundRobin`, `WeightedLeastRequest`, `Cookie`, and `RequestHash`.
+                        If an unknown strategy name is specified or no policy is supplied,
+                        the default `RoundRobin` policy is used.
+                      type: string
+                  type: object
+                protocol:
+                  description: Protocol may be used to specify (or override) the protocol
+                    used to reach this Service. Values may be h2 or h2c. If omitted,
+                    protocol-selection falls back on Service annotations.
+                  enum:
+                    - h2
+                    - h2c
+                  type: string
+                protocolVersion:
+                  description: This field sets the version of the GRPC protocol that
+                    Envoy uses to send requests to the extension service. Since Contour
+                    always uses the v3 Envoy API, this is currently fixed at "v3". However,
+                    other protocol options will be available in future.
+                  enum:
+                    - v3
+                  type: string
+                services:
+                  description: Services specifies the set of Kubernetes Service resources
+                    that receive GRPC extension API requests. If no weights are specified
+                    for any of the entries in this array, traffic will be spread evenly
+                    across all the services. Otherwise, traffic is balanced proportionally
+                    to the Weight field in each entry.
+                  items:
+                    description: ExtensionServiceTarget defines an Kubernetes Service
+                      to target with extension service traffic.
+                    properties:
+                      name:
+                        description: Name is the name of Kubernetes service that will
+                          accept service traffic.
+                        type: string
+                      port:
+                        description: Port (defined as Integer) to proxy traffic to since
+                          a service can have multiple defined.
+                        exclusiveMaximum: true
+                        maximum: 65536
+                        minimum: 1
+                        type: integer
+                      weight:
+                        description: Weight defines proportion of traffic to balance
+                          to the Kubernetes Service.
+                        format: int32
+                        type: integer
+                    required:
+                      - name
+                      - port
+                    type: object
+                  minItems: 1
+                  type: array
+                timeoutPolicy:
+                  description: The timeout policy for requests to the services.
+                  properties:
+                    idle:
+                      description: Timeout for how long the proxy should wait while
+                        there is no activity during single request/response (for HTTP/1.1)
+                        or stream (for HTTP/2). Timeout will not trigger while HTTP/1.1
+                        connection is idle between two consecutive requests. If not
+                        specified, there is no per-route idle timeout, though a connection
+                        manager-wide stream_idle_timeout default of 5m still applies.
+                      pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                      type: string
+                    idleConnection:
+                      description: Timeout for how long connection from the proxy to
+                        the upstream service is kept when there are no active requests.
+                        If not supplied, Envoy's default value of 1h applies.
+                      pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                      type: string
+                    response:
+                      description: Timeout for receiving a response from the server
+                        after processing a request from client. If not supplied, Envoy's
+                        default value of 15s applies.
+                      pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                      type: string
+                  type: object
+                validation:
+                  description: UpstreamValidation defines how to verify the backend
+                    service's certificate
+                  properties:
+                    caSecret:
+                      description: Name or namespaced name of the Kubernetes secret
+                        used to validate the certificate presented by the backend. The
+                        secret must contain key named ca.crt. The name can be optionally
+                        prefixed with namespace "namespace/name". When cross-namespace
+                        reference is used, TLSCertificateDelegation resource must exist
+                        in the namespace to grant access to the secret.
+                      type: string
+                    subjectName:
+                      description: Key which is expected to be present in the 'subjectAltName'
+                        of the presented certificate.
+                      type: string
+                  required:
+                    - caSecret
+                    - subjectName
+                  type: object
+              required:
+                - services
+              type: object
+            status:
+              description: ExtensionServiceStatus defines the observed state of an ExtensionService
+                resource.
+              properties:
+                conditions:
+                  description: "Conditions contains the current status of the ExtensionService
+                  resource. \n Contour will update a single condition, `Valid`, that
+                  is in normal-true polarity. \n Contour will not modify any other
+                  Conditions set in this block, in case some other controller wants
+                  to add a Condition."
+                  items:
+                    description: "DetailedCondition is an extension of the normal Kubernetes
+                    conditions, with two extra fields to hold sub-conditions, which
+                    provide more detailed reasons for the state (True or False) of
+                    the condition. \n `errors` holds information about sub-conditions
+                    which are fatal to that condition and render its state False.
+                    \n `warnings` holds information about sub-conditions which are
+                    not fatal to that condition and do not force the state to be False.
+                    \n Remember that Conditions have a type, a status, and a reason.
+                    \n The type is the type of the condition, the most important one
+                    in this CRD set is `Valid`. `Valid` is a positive-polarity condition:
+                    when it is `status: true` there are no problems. \n In more detail,
+                    `status: true` means that the object is has been ingested into
+                    Contour with no errors. `warnings` may still be present, and will
+                    be indicated in the Reason field. There must be zero entries in
+                    the `errors` slice in this case. \n `Valid`, `status: false` means
+                    that the object has had one or more fatal errors during processing
+                    into Contour. The details of the errors will be present under
+                    the `errors` field. There must be at least one error in the `errors`
+                    slice if `status` is `false`. \n For DetailedConditions of types
+                    other than `Valid`, the Condition must be in the negative polarity.
+                    When they have `status` `true`, there is an error. There must
+                    be at least one entry in the `errors` Subcondition slice. When
+                    they have `status` `false`, there are no serious errors, and there
+                    must be zero entries in the `errors` slice. In either case, there
+                    may be entries in the `warnings` slice. \n Regardless of the polarity,
+                    the `reason` and `message` fields must be updated with either
+                    the detail of the reason (if there is one and only one entry in
+                    total across both the `errors` and `warnings` slices), or `MultipleReasons`
+                    if there is more than one entry."
+                    properties:
+                      errors:
+                        description: "Errors contains a slice of relevant error subconditions
+                        for this object. \n Subconditions are expected to appear when
+                        relevant (when there is a error), and disappear when not relevant.
+                        An empty slice here indicates no errors."
+                        items:
+                          description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition
+                          transitioned from one status to another. This should be when
+                          the underlying condition changed.  If that is not known, then
+                          using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating
+                          details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if .metadata.generation
+                          is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition. Producers
+                          of specific condition types may define expected values and
+                          meanings for this field, and whether the values are considered
+                          a guaranteed API. The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          --- Many .condition.type values are consistent across resources
+                          like Available, but because arbitrary conditions can be useful
+                          (see .node.status.conditions), the ability to deconflict is
+                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                      warnings:
+                        description: "Warnings contains a slice of relevant warning
+                        subconditions for this object. \n Subconditions are expected
+                        to appear when relevant (when there is a warning), and disappear
+                        when not relevant. An empty slice here indicates no warnings."
+                        items:
+                          description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: httpproxies.projectcontour.io
+spec:
+  preserveUnknownFields: false
+  group: projectcontour.io
+  names:
+    kind: HTTPProxy
+    listKind: HTTPProxyList
+    plural: httpproxies
+    shortNames:
+      - proxy
+      - proxies
+    singular: httpproxy
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Fully qualified domain name
+          jsonPath: .spec.virtualhost.fqdn
+          name: FQDN
+          type: string
+        - description: Secret with TLS credentials
+          jsonPath: .spec.virtualhost.tls.secretName
+          name: TLS Secret
+          type: string
+        - description: The current status of the HTTPProxy
+          jsonPath: .status.currentStatus
+          name: Status
+          type: string
+        - description: Description of the current status
+          jsonPath: .status.description
+          name: Status Description
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: HTTPProxy is an Ingress CRD specification.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HTTPProxySpec defines the spec of the CRD.
+              properties:
+                includes:
+                  description: Includes allow for specific routing configuration to
+                    be included from another HTTPProxy, possibly in another namespace.
+                  items:
+                    description: Include describes a set of policies that can be applied
+                      to an HTTPProxy in a namespace.
+                    properties:
+                      conditions:
+                        description: 'Conditions are a set of rules that are applied
+                        to included HTTPProxies. In effect, they are added onto the
+                        Conditions of included HTTPProxy Route structs. When applied,
+                        they are merged using AND, with one exception: There can be
+                        only one Prefix MatchCondition per Conditions slice. More
+                        than one Prefix, or contradictory Conditions, will make the
+                        include invalid. Exact and Regex match conditions are not
+                        allowed on includes.'
+                        items:
+                          description: MatchCondition are a general holder for matching
+                            rules for HTTPProxies. One of Prefix, Exact, Regex, Header
+                            or QueryParameter must be provided.
+                          properties:
+                            exact:
+                              description: Exact defines a exact match for a request.
+                                This field is not allowed in include match conditions.
+                              type: string
+                            header:
+                              description: Header specifies the header condition to
+                                match.
+                              properties:
+                                contains:
+                                  description: Contains specifies a substring that must
+                                    be present in the header value.
+                                  type: string
+                                exact:
+                                  description: Exact specifies a string that the header
+                                    value must be equal to.
+                                  type: string
+                                name:
+                                  description: Name is the name of the header to match
+                                    against. Name is required. Header names are case
+                                    insensitive.
+                                  type: string
+                                notcontains:
+                                  description: NotContains specifies a substring that
+                                    must not be present in the header value.
+                                  type: string
+                                notexact:
+                                  description: NoExact specifies a string that the header
+                                    value must not be equal to. The condition is true
+                                    if the header has any other value.
+                                  type: string
+                                notpresent:
+                                  description: NotPresent specifies that condition is
+                                    true when the named header is not present. Note
+                                    that setting NotPresent to false does not make the
+                                    condition true if the named header is present.
+                                  type: boolean
+                                present:
+                                  description: Present specifies that condition is true
+                                    when the named header is present, regardless of
+                                    its value. Note that setting Present to false does
+                                    not make the condition true if the named header
+                                    is absent.
+                                  type: boolean
+                                regex:
+                                  description: Regex specifies a regular expression
+                                    pattern that must match the header value.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            prefix:
+                              description: Prefix defines a prefix match for a request.
+                              type: string
+                            queryParameter:
+                              description: QueryParameter specifies the query parameter
+                                condition to match.
+                              properties:
+                                contains:
+                                  description: Contains specifies a substring that must
+                                    be present in the query parameter value.
+                                  type: string
+                                exact:
+                                  description: Exact specifies a string that the query
+                                    parameter value must be equal to.
+                                  type: string
+                                ignoreCase:
+                                  description: IgnoreCase specifies that string matching
+                                    should be case insensitive. Note that this has no
+                                    effect on the Regex parameter.
+                                  type: boolean
+                                name:
+                                  description: Name is the name of the query parameter
+                                    to match against. Name is required. Query parameter
+                                    names are case insensitive.
+                                  type: string
+                                prefix:
+                                  description: Prefix defines a prefix match for the
+                                    query parameter value.
+                                  type: string
+                                present:
+                                  description: Present specifies that condition is true
+                                    when the named query parameter is present, regardless
+                                    of its value. Note that setting Present to false
+                                    does not make the condition true if the named query
+                                    parameter is absent.
+                                  type: boolean
+                                regex:
+                                  description: Regex specifies a regular expression
+                                    pattern that must match the query parameter value.
+                                  type: string
+                                suffix:
+                                  description: Suffix defines a suffix match for a query
+                                    parameter value.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            regex:
+                              description: Regex defines a regex match for a request.
+                                This field is not allowed in include match conditions.
+                              type: string
+                          type: object
+                        type: array
+                      name:
+                        description: Name of the HTTPProxy
+                        type: string
+                      namespace:
+                        description: Namespace of the HTTPProxy to include. Defaults
+                          to the current namespace if not supplied.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                ingressClassName:
+                  description: IngressClassName optionally specifies the ingress class
+                    to use for this HTTPProxy. This replaces the deprecated `kubernetes.io/ingress.class`
+                    annotation. For backwards compatibility, when that annotation is
+                    set, it is given precedence over this field.
+                  type: string
+                routes:
+                  description: Routes are the ingress routes. If TCPProxy is present,
+                    Routes is ignored.
+                  items:
+                    description: Route contains the set of routes for a virtual host.
+                    properties:
+                      authPolicy:
+                        description: AuthPolicy updates the authorization policy that
+                          was set on the root HTTPProxy object for client requests that
+                          match this route.
+                        properties:
+                          context:
+                            additionalProperties:
+                              type: string
+                            description: Context is a set of key/value pairs that are
+                              sent to the authentication server in the check request.
+                              If a context is provided at an enclosing scope, the entries
+                              are merged such that the inner scope overrides matching
+                              keys from the outer scope.
+                            type: object
+                          disabled:
+                            description: When true, this field disables client request
+                              authentication for the scope of the policy.
+                            type: boolean
+                        type: object
+                      conditions:
+                        description: 'Conditions are a set of rules that are applied
+                        to a Route. When applied, they are merged using AND, with
+                        one exception: There can be only one Prefix, Exact or Regex
+                        MatchCondition per Conditions slice. More than one of these
+                        condition types, or contradictory Conditions, will make the
+                        route invalid.'
+                        items:
+                          description: MatchCondition are a general holder for matching
+                            rules for HTTPProxies. One of Prefix, Exact, Regex, Header
+                            or QueryParameter must be provided.
+                          properties:
+                            exact:
+                              description: Exact defines a exact match for a request.
+                                This field is not allowed in include match conditions.
+                              type: string
+                            header:
+                              description: Header specifies the header condition to
+                                match.
+                              properties:
+                                contains:
+                                  description: Contains specifies a substring that must
+                                    be present in the header value.
+                                  type: string
+                                exact:
+                                  description: Exact specifies a string that the header
+                                    value must be equal to.
+                                  type: string
+                                name:
+                                  description: Name is the name of the header to match
+                                    against. Name is required. Header names are case
+                                    insensitive.
+                                  type: string
+                                notcontains:
+                                  description: NotContains specifies a substring that
+                                    must not be present in the header value.
+                                  type: string
+                                notexact:
+                                  description: NoExact specifies a string that the header
+                                    value must not be equal to. The condition is true
+                                    if the header has any other value.
+                                  type: string
+                                notpresent:
+                                  description: NotPresent specifies that condition is
+                                    true when the named header is not present. Note
+                                    that setting NotPresent to false does not make the
+                                    condition true if the named header is present.
+                                  type: boolean
+                                present:
+                                  description: Present specifies that condition is true
+                                    when the named header is present, regardless of
+                                    its value. Note that setting Present to false does
+                                    not make the condition true if the named header
+                                    is absent.
+                                  type: boolean
+                                regex:
+                                  description: Regex specifies a regular expression
+                                    pattern that must match the header value.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            prefix:
+                              description: Prefix defines a prefix match for a request.
+                              type: string
+                            queryParameter:
+                              description: QueryParameter specifies the query parameter
+                                condition to match.
+                              properties:
+                                contains:
+                                  description: Contains specifies a substring that must
+                                    be present in the query parameter value.
+                                  type: string
+                                exact:
+                                  description: Exact specifies a string that the query
+                                    parameter value must be equal to.
+                                  type: string
+                                ignoreCase:
+                                  description: IgnoreCase specifies that string matching
+                                    should be case insensitive. Note that this has no
+                                    effect on the Regex parameter.
+                                  type: boolean
+                                name:
+                                  description: Name is the name of the query parameter
+                                    to match against. Name is required. Query parameter
+                                    names are case insensitive.
+                                  type: string
+                                prefix:
+                                  description: Prefix defines a prefix match for the
+                                    query parameter value.
+                                  type: string
+                                present:
+                                  description: Present specifies that condition is true
+                                    when the named query parameter is present, regardless
+                                    of its value. Note that setting Present to false
+                                    does not make the condition true if the named query
+                                    parameter is absent.
+                                  type: boolean
+                                regex:
+                                  description: Regex specifies a regular expression
+                                    pattern that must match the query parameter value.
+                                  type: string
+                                suffix:
+                                  description: Suffix defines a suffix match for a query
+                                    parameter value.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            regex:
+                              description: Regex defines a regex match for a request.
+                                This field is not allowed in include match conditions.
+                              type: string
+                          type: object
+                        type: array
+                      cookieRewritePolicies:
+                        description: The policies for rewriting Set-Cookie header attributes.
+                          Note that rewritten cookie names must be unique in this list.
+                          Order rewrite policies are specified in does not matter.
+                        items:
+                          properties:
+                            domainRewrite:
+                              description: DomainRewrite enables rewriting the Set-Cookie
+                                Domain element. If not set, Domain will not be rewritten.
+                              properties:
+                                value:
+                                  description: Value is the value to rewrite the Domain
+                                    attribute to. For now this is required.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                            name:
+                              description: Name is the name of the cookie for which
+                                attributes will be rewritten.
+                              maxLength: 4096
+                              minLength: 1
+                              pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                              type: string
+                            pathRewrite:
+                              description: PathRewrite enables rewriting the Set-Cookie
+                                Path element. If not set, Path will not be rewritten.
+                              properties:
+                                value:
+                                  description: Value is the value to rewrite the Path
+                                    attribute to. For now this is required.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                            sameSite:
+                              description: SameSite enables rewriting the Set-Cookie
+                                SameSite element. If not set, SameSite attribute will
+                                not be rewritten.
+                              enum:
+                                - Strict
+                                - Lax
+                                - None
+                              type: string
+                            secure:
+                              description: Secure enables rewriting the Set-Cookie Secure
+                                element. If not set, Secure attribute will not be rewritten.
+                              type: boolean
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      directResponsePolicy:
+                        description: DirectResponsePolicy returns an arbitrary HTTP
+                          response directly.
+                        properties:
+                          body:
+                            description: "Body is the content of the response body.
+                            If this setting is omitted, no body is included in the
+                            generated response. \n Note: Body is not recommended to
+                            set too long otherwise it can have significant resource
+                            usage impacts."
+                            type: string
+                          statusCode:
+                            description: StatusCode is the HTTP response status to be
+                              returned.
+                            maximum: 599
+                            minimum: 200
+                            type: integer
+                        required:
+                          - statusCode
+                        type: object
+                      enableWebsockets:
+                        description: Enables websocket support for the route.
+                        type: boolean
+                      healthCheckPolicy:
+                        description: The health check policy for this route.
+                        properties:
+                          expectedStatuses:
+                            description: The ranges of HTTP response statuses considered
+                              healthy. Follow half-open semantics, i.e. for each range
+                              the start is inclusive and the end is exclusive. Must
+                              be within the range [100,600). If not specified, only
+                              a 200 response status is considered healthy.
+                            items:
+                              properties:
+                                end:
+                                  description: The end (exclusive) of a range of HTTP
+                                    status codes.
+                                  format: int64
+                                  maximum: 600
+                                  minimum: 101
+                                  type: integer
+                                start:
+                                  description: The start (inclusive) of a range of HTTP
+                                    status codes.
+                                  format: int64
+                                  maximum: 599
+                                  minimum: 100
+                                  type: integer
+                              required:
+                                - end
+                                - start
+                              type: object
+                            type: array
+                          healthyThresholdCount:
+                            description: The number of healthy health checks required
+                              before a host is marked healthy
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          host:
+                            description: The value of the host header in the HTTP health
+                              check request. If left empty (default value), the name
+                              "contour-envoy-healthcheck" will be used.
+                            type: string
+                          intervalSeconds:
+                            description: The interval (seconds) between health checks
+                            format: int64
+                            type: integer
+                          path:
+                            description: HTTP endpoint used to perform health checks
+                              on upstream service
+                            type: string
+                          timeoutSeconds:
+                            description: The time to wait (seconds) for a health check
+                              response
+                            format: int64
+                            type: integer
+                          unhealthyThresholdCount:
+                            description: The number of unhealthy health checks required
+                              before a host is marked unhealthy
+                            format: int64
+                            minimum: 0
+                            type: integer
+                        required:
+                          - path
+                        type: object
+                      internalRedirectPolicy:
+                        description: The policy to define when to handle redirects responses
+                          internally.
+                        properties:
+                          allowCrossSchemeRedirect:
+                            default: Never
+                            description: AllowCrossSchemeRedirect Allow internal redirect
+                              to follow a target URI with a different scheme than the
+                              value of x-forwarded-proto. SafeOnly allows same scheme
+                              redirect and safe cross scheme redirect, which means if
+                              the downstream scheme is HTTPS, both HTTPS and HTTP redirect
+                              targets are allowed, but if the downstream scheme is HTTP,
+                              only HTTP redirect targets are allowed.
+                            enum:
+                              - Always
+                              - Never
+                              - SafeOnly
+                            type: string
+                          denyRepeatedRouteRedirect:
+                            description: If DenyRepeatedRouteRedirect is true, rejects
+                              redirect targets that are pointing to a route that has
+                              been followed by a previous redirect from the current
+                              route.
+                            type: boolean
+                          maxInternalRedirects:
+                            description: MaxInternalRedirects An internal redirect is
+                              not handled, unless the number of previous internal redirects
+                              that a downstream request has encountered is lower than
+                              this value.
+                            format: int32
+                            type: integer
+                          redirectResponseCodes:
+                            description: RedirectResponseCodes If unspecified, only
+                              302 will be treated as internal redirect. Only 301, 302,
+                              303, 307 and 308 are valid values.
+                            items:
+                              description: RedirectResponseCode is a uint32 type alias
+                                with validation to ensure that the value is valid.
+                              enum:
+                                - 301
+                                - 302
+                                - 303
+                                - 307
+                                - 308
+                              format: int32
+                              type: integer
+                            type: array
+                        type: object
+                      ipAllowPolicy:
+                        description: IPAllowFilterPolicy is a list of ipv4/6 filter
+                          rules for which matching requests should be allowed. All other
+                          requests will be denied. Only one of IPAllowFilterPolicy and
+                          IPDenyFilterPolicy can be defined. The rules defined here
+                          override any rules set on the root HTTPProxy.
+                        items:
+                          properties:
+                            cidr:
+                              description: CIDR is a CIDR block of ipv4 or ipv6 addresses
+                                to filter on. This can also be a bare IP address (without
+                                a mask) to filter on exactly one address.
+                              type: string
+                            source:
+                              description: 'Source indicates how to determine the ip
+                              address to filter on, and can be one of two values:
+                              - `Remote` filters on the ip address of the client,
+                              accounting for PROXY and X-Forwarded-For as needed.
+                              - `Peer` filters on the ip of the network request, ignoring
+                              PROXY and X-Forwarded-For.'
+                              enum:
+                                - Peer
+                                - Remote
+                              type: string
+                          required:
+                            - cidr
+                            - source
+                          type: object
+                        type: array
+                      ipDenyPolicy:
+                        description: IPDenyFilterPolicy is a list of ipv4/6 filter rules
+                          for which matching requests should be denied. All other requests
+                          will be allowed. Only one of IPAllowFilterPolicy and IPDenyFilterPolicy
+                          can be defined. The rules defined here override any rules
+                          set on the root HTTPProxy.
+                        items:
+                          properties:
+                            cidr:
+                              description: CIDR is a CIDR block of ipv4 or ipv6 addresses
+                                to filter on. This can also be a bare IP address (without
+                                a mask) to filter on exactly one address.
+                              type: string
+                            source:
+                              description: 'Source indicates how to determine the ip
+                              address to filter on, and can be one of two values:
+                              - `Remote` filters on the ip address of the client,
+                              accounting for PROXY and X-Forwarded-For as needed.
+                              - `Peer` filters on the ip of the network request, ignoring
+                              PROXY and X-Forwarded-For.'
+                              enum:
+                                - Peer
+                                - Remote
+                              type: string
+                          required:
+                            - cidr
+                            - source
+                          type: object
+                        type: array
+                      jwtVerificationPolicy:
+                        description: The policy for verifying JWTs for requests to this
+                          route.
+                        properties:
+                          disabled:
+                            description: Disabled defines whether to disable all JWT
+                              verification for this route. This can be used to opt specific
+                              routes out of the default JWT provider for the HTTPProxy.
+                              At most one of this field or the "require" field can be
+                              specified.
+                            type: boolean
+                          require:
+                            description: Require names a specific JWT provider (defined
+                              in the virtual host) to require for the route. If specified,
+                              this field overrides the default provider if one exists.
+                              If this field is not specified, the default provider will
+                              be required if one exists. At most one of this field or
+                              the "disabled" field can be specified.
+                            type: string
+                        type: object
+                      loadBalancerPolicy:
+                        description: The load balancing policy for this route.
+                        properties:
+                          requestHashPolicies:
+                            description: RequestHashPolicies contains a list of hash
+                              policies to apply when the `RequestHash` load balancing
+                              strategy is chosen. If an element of the supplied list
+                              of hash policies is invalid, it will be ignored. If the
+                              list of hash policies is empty after validation, the load
+                              balancing strategy will fall back to the default `RoundRobin`.
+                            items:
+                              description: RequestHashPolicy contains configuration
+                                for an individual hash policy on a request attribute.
+                              properties:
+                                hashSourceIP:
+                                  description: HashSourceIP should be set to true when
+                                    request source IP hash based load balancing is desired.
+                                    It must be the only hash option field set, otherwise
+                                    this request hash policy object will be ignored.
+                                  type: boolean
+                                headerHashOptions:
+                                  description: HeaderHashOptions should be set when
+                                    request header hash based load balancing is desired.
+                                    It must be the only hash option field set, otherwise
+                                    this request hash policy object will be ignored.
+                                  properties:
+                                    headerName:
+                                      description: HeaderName is the name of the HTTP
+                                        request header that will be used to calculate
+                                        the hash key. If the header specified is not
+                                        present on a request, no hash will be produced.
+                                      minLength: 1
+                                      type: string
+                                  type: object
+                                queryParameterHashOptions:
+                                  description: QueryParameterHashOptions should be set
+                                    when request query parameter hash based load balancing
+                                    is desired. It must be the only hash option field
+                                    set, otherwise this request hash policy object will
+                                    be ignored.
+                                  properties:
+                                    parameterName:
+                                      description: ParameterName is the name of the
+                                        HTTP request query parameter that will be used
+                                        to calculate the hash key. If the query parameter
+                                        specified is not present on a request, no hash
+                                        will be produced.
+                                      minLength: 1
+                                      type: string
+                                  type: object
+                                terminal:
+                                  description: Terminal is a flag that allows for short-circuiting
+                                    computing of a hash for a given request. If set
+                                    to true, and the request attribute specified in
+                                    the attribute hash options is present, no further
+                                    hash policies will be used to calculate a hash for
+                                    the request.
+                                  type: boolean
+                              type: object
+                            type: array
+                          strategy:
+                            description: Strategy specifies the policy used to balance
+                              requests across the pool of backend pods. Valid policy
+                              names are `Random`, `RoundRobin`, `WeightedLeastRequest`,
+                              `Cookie`, and `RequestHash`. If an unknown strategy name
+                              is specified or no policy is supplied, the default `RoundRobin`
+                              policy is used.
+                            type: string
+                        type: object
+                      pathRewritePolicy:
+                        description: The policy for rewriting the path of the request
+                          URL after the request has been routed to a Service.
+                        properties:
+                          replacePrefix:
+                            description: ReplacePrefix describes how the path prefix
+                              should be replaced.
+                            items:
+                              description: ReplacePrefix describes a path prefix replacement.
+                              properties:
+                                prefix:
+                                  description: "Prefix specifies the URL path prefix
+                                  to be replaced. \n If Prefix is specified, it must
+                                  exactly match the MatchCondition prefix that is
+                                  rendered by the chain of including HTTPProxies and
+                                  only that path prefix will be replaced by Replacement.
+                                  This allows HTTPProxies that are included through
+                                  multiple roots to only replace specific path prefixes,
+                                  leaving others unmodified. \n If Prefix is not specified,
+                                  all routing prefixes rendered by the include chain
+                                  will be replaced."
+                                  minLength: 1
+                                  type: string
+                                replacement:
+                                  description: Replacement is the string that the routing
+                                    path prefix will be replaced with. This must not
+                                    be empty.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - replacement
+                              type: object
+                            type: array
+                        type: object
+                      permitInsecure:
+                        description: Allow this path to respond to insecure requests
+                          over HTTP which are normally not permitted when a `virtualhost.tls`
+                          block is present.
+                        type: boolean
+                      rateLimitPolicy:
+                        description: The policy for rate limiting on the route.
+                        properties:
+                          global:
+                            description: Global defines global rate limiting parameters,
+                              i.e. parameters defining descriptors that are sent to
+                              an external rate limit service (RLS) for a rate limit
+                              decision on each request.
+                            properties:
+                              descriptors:
+                                description: Descriptors defines the list of descriptors
+                                  that will be generated and sent to the rate limit
+                                  service. Each descriptor contains 1+ key-value pair
+                                  entries.
+                                items:
+                                  description: RateLimitDescriptor defines a list of
+                                    key-value pair generators.
+                                  properties:
+                                    entries:
+                                      description: Entries is the list of key-value
+                                        pair generators.
+                                      items:
+                                        description: RateLimitDescriptorEntry is a key-value
+                                          pair generator. Exactly one field on this
+                                          struct must be non-nil.
+                                        properties:
+                                          genericKey:
+                                            description: GenericKey defines a descriptor
+                                              entry with a static key and value.
+                                            properties:
+                                              key:
+                                                description: Key defines the key of
+                                                  the descriptor entry. If not set,
+                                                  the key is set to "generic_key".
+                                                type: string
+                                              value:
+                                                description: Value defines the value
+                                                  of the descriptor entry.
+                                                minLength: 1
+                                                type: string
+                                            type: object
+                                          remoteAddress:
+                                            description: RemoteAddress defines a descriptor
+                                              entry with a key of "remote_address" and
+                                              a value equal to the client's IP address
+                                              (from x-forwarded-for).
+                                            type: object
+                                          requestHeader:
+                                            description: RequestHeader defines a descriptor
+                                              entry that's populated only if a given
+                                              header is present on the request. The
+                                              descriptor key is static, and the descriptor
+                                              value is equal to the value of the header.
+                                            properties:
+                                              descriptorKey:
+                                                description: DescriptorKey defines the
+                                                  key to use on the descriptor entry.
+                                                minLength: 1
+                                                type: string
+                                              headerName:
+                                                description: HeaderName defines the
+                                                  name of the header to look for on
+                                                  the request.
+                                                minLength: 1
+                                                type: string
+                                            type: object
+                                          requestHeaderValueMatch:
+                                            description: RequestHeaderValueMatch defines
+                                              a descriptor entry that's populated if
+                                              the request's headers match a set of 1+
+                                              match criteria. The descriptor key is
+                                              "header_match", and the descriptor value
+                                              is static.
+                                            properties:
+                                              expectMatch:
+                                                default: true
+                                                description: ExpectMatch defines whether
+                                                  the request must positively match
+                                                  the match criteria in order to generate
+                                                  a descriptor entry (i.e. true), or
+                                                  not match the match criteria in order
+                                                  to generate a descriptor entry (i.e.
+                                                  false). The default is true.
+                                                type: boolean
+                                              headers:
+                                                description: Headers is a list of 1+
+                                                  match criteria to apply against the
+                                                  request to determine whether to populate
+                                                  the descriptor entry or not.
+                                                items:
+                                                  description: HeaderMatchCondition
+                                                    specifies how to conditionally match
+                                                    against HTTP headers. The Name field
+                                                    is required, but only one of the
+                                                    remaining fields should be be provided.
+                                                  properties:
+                                                    contains:
+                                                      description: Contains specifies
+                                                        a substring that must be present
+                                                        in the header value.
+                                                      type: string
+                                                    exact:
+                                                      description: Exact specifies a
+                                                        string that the header value
+                                                        must be equal to.
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name
+                                                        of the header to match against.
+                                                        Name is required. Header names
+                                                        are case insensitive.
+                                                      type: string
+                                                    notcontains:
+                                                      description: NotContains specifies
+                                                        a substring that must not be
+                                                        present in the header value.
+                                                      type: string
+                                                    notexact:
+                                                      description: NoExact specifies
+                                                        a string that the header value
+                                                        must not be equal to. The condition
+                                                        is true if the header has any
+                                                        other value.
+                                                      type: string
+                                                    notpresent:
+                                                      description: NotPresent specifies
+                                                        that condition is true when
+                                                        the named header is not present.
+                                                        Note that setting NotPresent
+                                                        to false does not make the condition
+                                                        true if the named header is
+                                                        present.
+                                                      type: boolean
+                                                    present:
+                                                      description: Present specifies
+                                                        that condition is true when
+                                                        the named header is present,
+                                                        regardless of its value. Note
+                                                        that setting Present to false
+                                                        does not make the condition
+                                                        true if the named header is
+                                                        absent.
+                                                      type: boolean
+                                                    regex:
+                                                      description: Regex specifies a
+                                                        regular expression pattern that
+                                                        must match the header value.
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                  type: object
+                                                minItems: 1
+                                                type: array
+                                              value:
+                                                description: Value defines the value
+                                                  of the descriptor entry.
+                                                minLength: 1
+                                                type: string
+                                            type: object
+                                        type: object
+                                      minItems: 1
+                                      type: array
+                                  type: object
+                                minItems: 1
+                                type: array
+                              disabled:
+                                description: Disabled configures the HTTPProxy to not
+                                  use the default global rate limit policy defined by
+                                  the Contour configuration.
+                                type: boolean
+                            type: object
+                          local:
+                            description: Local defines local rate limiting parameters,
+                              i.e. parameters for rate limiting that occurs within each
+                              Envoy pod as requests are handled.
+                            properties:
+                              burst:
+                                description: Burst defines the number of requests above
+                                  the requests per unit that should be allowed within
+                                  a short period of time.
+                                format: int32
+                                type: integer
+                              requests:
+                                description: Requests defines how many requests per
+                                  unit of time should be allowed before rate limiting
+                                  occurs.
+                                format: int32
+                                minimum: 1
+                                type: integer
+                              responseHeadersToAdd:
+                                description: ResponseHeadersToAdd is an optional list
+                                  of response headers to set when a request is rate-limited.
+                                items:
+                                  description: HeaderValue represents a header name/value
+                                    pair
+                                  properties:
+                                    name:
+                                      description: Name represents a key of a header
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: Value represents the value of a header
+                                        specified by a key
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                    - name
+                                    - value
+                                  type: object
+                                type: array
+                              responseStatusCode:
+                                description: ResponseStatusCode is the HTTP status code
+                                  to use for responses to rate-limited requests. Codes
+                                  must be in the 400-599 range (inclusive). If not specified,
+                                  the Envoy default of 429 (Too Many Requests) is used.
+                                format: int32
+                                maximum: 599
+                                minimum: 400
+                                type: integer
+                              unit:
+                                description: Unit defines the period of time within
+                                  which requests over the limit will be rate limited.
+                                  Valid values are "second", "minute" and "hour".
+                                enum:
+                                  - second
+                                  - minute
+                                  - hour
+                                type: string
+                            required:
+                              - requests
+                              - unit
+                            type: object
+                        type: object
+                      requestHeadersPolicy:
+                        description: The policy for managing request headers during
+                          proxying.
+                        properties:
+                          remove:
+                            description: Remove specifies a list of HTTP header names
+                              to remove.
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            description: Set specifies a list of HTTP header values
+                              that will be set in the HTTP header. If the header does
+                              not exist it will be added, otherwise it will be overwritten
+                              with the new value.
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                        type: object
+                      requestRedirectPolicy:
+                        description: RequestRedirectPolicy defines an HTTP redirection.
+                        properties:
+                          hostname:
+                            description: Hostname is the precise hostname to be used
+                              in the value of the `Location` header in the response.
+                              When empty, the hostname of the request is used. No wildcards
+                              are allowed.
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          path:
+                            description: "Path allows for redirection to a different
+                            path from the original on the request. The path must start
+                            with a leading slash. \n Note: Only one of Path or Prefix
+                            can be defined."
+                            pattern: ^\/.*$
+                            type: string
+                          port:
+                            description: Port is the port to be used in the value of
+                              the `Location` header in the response. When empty, port
+                              (if specified) of the request is used.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          prefix:
+                            description: "Prefix defines the value to swap the matched
+                            prefix or path with. The prefix must start with a leading
+                            slash. \n Note: Only one of Path or Prefix can be defined."
+                            pattern: ^\/.*$
+                            type: string
+                          scheme:
+                            description: Scheme is the scheme to be used in the value
+                              of the `Location` header in the response. When empty,
+                              the scheme of the request is used.
+                            enum:
+                              - http
+                              - https
+                            type: string
+                          statusCode:
+                            default: 302
+                            description: StatusCode is the HTTP status code to be used
+                              in response.
+                            enum:
+                              - 301
+                              - 302
+                            type: integer
+                        type: object
+                      responseHeadersPolicy:
+                        description: The policy for managing response headers during
+                          proxying. Rewriting the 'Host' header is not supported.
+                        properties:
+                          remove:
+                            description: Remove specifies a list of HTTP header names
+                              to remove.
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            description: Set specifies a list of HTTP header values
+                              that will be set in the HTTP header. If the header does
+                              not exist it will be added, otherwise it will be overwritten
+                              with the new value.
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                        type: object
+                      retryPolicy:
+                        description: The retry policy for this route.
+                        properties:
+                          count:
+                            default: 1
+                            description: NumRetries is maximum allowed number of retries.
+                              If set to -1, then retries are disabled. If set to 0 or
+                              not supplied, the value is set to the Envoy default of
+                              1.
+                            format: int64
+                            minimum: -1
+                            type: integer
+                          perTryTimeout:
+                            description: PerTryTimeout specifies the timeout per retry
+                              attempt. Ignored if NumRetries is not supplied.
+                            pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                            type: string
+                          retriableStatusCodes:
+                            description: "RetriableStatusCodes specifies the HTTP status
+                            codes that should be retried. \n This field is only respected
+                            when you include `retriable-status-codes` in the `RetryOn`
+                            field."
+                            items:
+                              format: int32
+                              type: integer
+                            type: array
+                          retryOn:
+                            description: "RetryOn specifies the conditions on which
+                            to retry a request. \n Supported [HTTP conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on):
+                            \n - `5xx` - `gateway-error` - `reset` - `connect-failure`
+                            - `retriable-4xx` - `refused-stream` - `retriable-status-codes`
+                            - `retriable-headers` \n Supported [gRPC conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on):
+                            \n - `cancelled` - `deadline-exceeded` - `internal` -
+                            `resource-exhausted` - `unavailable`"
+                            items:
+                              description: RetryOn is a string type alias with validation
+                                to ensure that the value is valid.
+                              enum:
+                                - 5xx
+                                - gateway-error
+                                - reset
+                                - connect-failure
+                                - retriable-4xx
+                                - refused-stream
+                                - retriable-status-codes
+                                - retriable-headers
+                                - cancelled
+                                - deadline-exceeded
+                                - internal
+                                - resource-exhausted
+                                - unavailable
+                              type: string
+                            type: array
+                        type: object
+                      services:
+                        description: Services are the services to proxy traffic.
+                        items:
+                          description: Service defines an Kubernetes Service to proxy
+                            traffic.
+                          properties:
+                            cookieRewritePolicies:
+                              description: The policies for rewriting Set-Cookie header
+                                attributes.
+                              items:
+                                properties:
+                                  domainRewrite:
+                                    description: DomainRewrite enables rewriting the
+                                      Set-Cookie Domain element. If not set, Domain
+                                      will not be rewritten.
+                                    properties:
+                                      value:
+                                        description: Value is the value to rewrite the
+                                          Domain attribute to. For now this is required.
+                                        maxLength: 4096
+                                        minLength: 1
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        type: string
+                                    required:
+                                      - value
+                                    type: object
+                                  name:
+                                    description: Name is the name of the cookie for
+                                      which attributes will be rewritten.
+                                    maxLength: 4096
+                                    minLength: 1
+                                    pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                    type: string
+                                  pathRewrite:
+                                    description: PathRewrite enables rewriting the Set-Cookie
+                                      Path element. If not set, Path will not be rewritten.
+                                    properties:
+                                      value:
+                                        description: Value is the value to rewrite the
+                                          Path attribute to. For now this is required.
+                                        maxLength: 4096
+                                        minLength: 1
+                                        pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                        type: string
+                                    required:
+                                      - value
+                                    type: object
+                                  sameSite:
+                                    description: SameSite enables rewriting the Set-Cookie
+                                      SameSite element. If not set, SameSite attribute
+                                      will not be rewritten.
+                                    enum:
+                                      - Strict
+                                      - Lax
+                                      - None
+                                    type: string
+                                  secure:
+                                    description: Secure enables rewriting the Set-Cookie
+                                      Secure element. If not set, Secure attribute will
+                                      not be rewritten.
+                                    type: boolean
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            healthPort:
+                              description: HealthPort is the port for this service healthcheck.
+                                If not specified, Port is used for service healthchecks.
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            mirror:
+                              description: 'If Mirror is true the Service will receive
+                              a read only mirror of the traffic for this route. If
+                              Mirror is true, then fractional mirroring can be enabled
+                              by optionally setting the Weight field. Legal values
+                              for Weight are 1-100. Omitting the Weight field will
+                              result in 100% mirroring. NOTE: Setting Weight explicitly
+                              to 0 will unexpectedly result in 100% traffic mirroring.
+                              This occurs since we cannot distinguish omitted fields
+                              from those explicitly set to their default values'
+                              type: boolean
+                            name:
+                              description: Name is the name of Kubernetes service to
+                                proxy traffic. Names defined here will be used to look
+                                up corresponding endpoints which contain the ips to
+                                route.
+                              type: string
+                            port:
+                              description: Port (defined as Integer) to proxy traffic
+                                to since a service can have multiple defined.
+                              exclusiveMaximum: true
+                              maximum: 65536
+                              minimum: 1
+                              type: integer
+                            protocol:
+                              description: Protocol may be used to specify (or override)
+                                the protocol used to reach this Service. Values may
+                                be tls, h2, h2c. If omitted, protocol-selection falls
+                                back on Service annotations.
+                              enum:
+                                - h2
+                                - h2c
+                                - tls
+                              type: string
+                            requestHeadersPolicy:
+                              description: The policy for managing request headers during
+                                proxying.
+                              properties:
+                                remove:
+                                  description: Remove specifies a list of HTTP header
+                                    names to remove.
+                                  items:
+                                    type: string
+                                  type: array
+                                set:
+                                  description: Set specifies a list of HTTP header values
+                                    that will be set in the HTTP header. If the header
+                                    does not exist it will be added, otherwise it will
+                                    be overwritten with the new value.
+                                  items:
+                                    description: HeaderValue represents a header name/value
+                                      pair
+                                    properties:
+                                      name:
+                                        description: Name represents a key of a header
+                                        minLength: 1
+                                        type: string
+                                      value:
+                                        description: Value represents the value of a
+                                          header specified by a key
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                              type: object
+                            responseHeadersPolicy:
+                              description: The policy for managing response headers
+                                during proxying. Rewriting the 'Host' header is not
+                                supported.
+                              properties:
+                                remove:
+                                  description: Remove specifies a list of HTTP header
+                                    names to remove.
+                                  items:
+                                    type: string
+                                  type: array
+                                set:
+                                  description: Set specifies a list of HTTP header values
+                                    that will be set in the HTTP header. If the header
+                                    does not exist it will be added, otherwise it will
+                                    be overwritten with the new value.
+                                  items:
+                                    description: HeaderValue represents a header name/value
+                                      pair
+                                    properties:
+                                      name:
+                                        description: Name represents a key of a header
+                                        minLength: 1
+                                        type: string
+                                      value:
+                                        description: Value represents the value of a
+                                          header specified by a key
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                              type: object
+                            slowStartPolicy:
+                              description: Slow start will gradually increase amount
+                                of traffic to a newly added endpoint.
+                              properties:
+                                aggression:
+                                  default: "1.0"
+                                  description: "The speed of traffic increase over the
+                                  slow start window. Defaults to 1.0, so that endpoint
+                                  would get linearly increasing amount of traffic.
+                                  When increasing the value for this parameter, the
+                                  speed of traffic ramp-up increases non-linearly.
+                                  The value of aggression parameter should be greater
+                                  than 0.0. \n More info: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/slow_start"
+                                  pattern: ^([0-9]+([.][0-9]+)?|[.][0-9]+)$
+                                  type: string
+                                minWeightPercent:
+                                  default: 10
+                                  description: The minimum or starting percentage of
+                                    traffic to send to new endpoints. A non-zero value
+                                    helps avoid a too small initial weight, which may
+                                    cause endpoints in slow start mode to receive no
+                                    traffic in the beginning of the slow start window.
+                                    If not specified, the default is 10%.
+                                  format: int32
+                                  maximum: 100
+                                  minimum: 0
+                                  type: integer
+                                window:
+                                  description: The duration of slow start window. Duration
+                                    is expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                                    Valid time units are "ns", "us" (or "µs"), "ms",
+                                    "s", "m", "h".
+                                  pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+)$
+                                  type: string
+                              required:
+                                - window
+                              type: object
+                            validation:
+                              description: UpstreamValidation defines how to verify
+                                the backend service's certificate
+                              properties:
+                                caSecret:
+                                  description: Name or namespaced name of the Kubernetes
+                                    secret used to validate the certificate presented
+                                    by the backend. The secret must contain key named
+                                    ca.crt. The name can be optionally prefixed with
+                                    namespace "namespace/name". When cross-namespace
+                                    reference is used, TLSCertificateDelegation resource
+                                    must exist in the namespace to grant access to the
+                                    secret.
+                                  type: string
+                                subjectName:
+                                  description: Key which is expected to be present in
+                                    the 'subjectAltName' of the presented certificate.
+                                  type: string
+                              required:
+                                - caSecret
+                                - subjectName
+                              type: object
+                            weight:
+                              description: Weight defines percentage of traffic to balance
+                                traffic
+                              format: int64
+                              minimum: 0
+                              type: integer
+                          required:
+                            - name
+                            - port
+                          type: object
+                        type: array
+                      timeoutPolicy:
+                        description: The timeout policy for this route.
+                        properties:
+                          idle:
+                            description: Timeout for how long the proxy should wait
+                              while there is no activity during single request/response
+                              (for HTTP/1.1) or stream (for HTTP/2). Timeout will not
+                              trigger while HTTP/1.1 connection is idle between two
+                              consecutive requests. If not specified, there is no per-route
+                              idle timeout, though a connection manager-wide stream_idle_timeout
+                              default of 5m still applies.
+                            pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                            type: string
+                          idleConnection:
+                            description: Timeout for how long connection from the proxy
+                              to the upstream service is kept when there are no active
+                              requests. If not supplied, Envoy's default value of 1h
+                              applies.
+                            pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                            type: string
+                          response:
+                            description: Timeout for receiving a response from the server
+                              after processing a request from client. If not supplied,
+                              Envoy's default value of 15s applies.
+                            pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+                tcpproxy:
+                  description: TCPProxy holds TCP proxy information.
+                  properties:
+                    healthCheckPolicy:
+                      description: The health check policy for this tcp proxy
+                      properties:
+                        healthyThresholdCount:
+                          description: The number of healthy health checks required
+                            before a host is marked healthy
+                          format: int32
+                          type: integer
+                        intervalSeconds:
+                          description: The interval (seconds) between health checks
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: The time to wait (seconds) for a health check
+                            response
+                          format: int64
+                          type: integer
+                        unhealthyThresholdCount:
+                          description: The number of unhealthy health checks required
+                            before a host is marked unhealthy
+                          format: int32
+                          type: integer
+                      type: object
+                    include:
+                      description: Include specifies that this tcpproxy should be delegated
+                        to another HTTPProxy.
+                      properties:
+                        name:
+                          description: Name of the child HTTPProxy
+                          type: string
+                        namespace:
+                          description: Namespace of the HTTPProxy to include. Defaults
+                            to the current namespace if not supplied.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    includes:
+                      description: "IncludesDeprecated allow for specific routing configuration
+                      to be appended to another HTTPProxy in another namespace. \n
+                      Exists due to a mistake when developing HTTPProxy and the field
+                      was marked plural when it should have been singular. This field
+                      should stay to not break backwards compatibility to v1 users."
+                      properties:
+                        name:
+                          description: Name of the child HTTPProxy
+                          type: string
+                        namespace:
+                          description: Namespace of the HTTPProxy to include. Defaults
+                            to the current namespace if not supplied.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    loadBalancerPolicy:
+                      description: The load balancing policy for the backend services.
+                        Note that the `Cookie` and `RequestHash` load balancing strategies
+                        cannot be used here.
+                      properties:
+                        requestHashPolicies:
+                          description: RequestHashPolicies contains a list of hash policies
+                            to apply when the `RequestHash` load balancing strategy
+                            is chosen. If an element of the supplied list of hash policies
+                            is invalid, it will be ignored. If the list of hash policies
+                            is empty after validation, the load balancing strategy will
+                            fall back to the default `RoundRobin`.
+                          items:
+                            description: RequestHashPolicy contains configuration for
+                              an individual hash policy on a request attribute.
+                            properties:
+                              hashSourceIP:
+                                description: HashSourceIP should be set to true when
+                                  request source IP hash based load balancing is desired.
+                                  It must be the only hash option field set, otherwise
+                                  this request hash policy object will be ignored.
+                                type: boolean
+                              headerHashOptions:
+                                description: HeaderHashOptions should be set when request
+                                  header hash based load balancing is desired. It must
+                                  be the only hash option field set, otherwise this
+                                  request hash policy object will be ignored.
+                                properties:
+                                  headerName:
+                                    description: HeaderName is the name of the HTTP
+                                      request header that will be used to calculate
+                                      the hash key. If the header specified is not present
+                                      on a request, no hash will be produced.
+                                    minLength: 1
+                                    type: string
+                                type: object
+                              queryParameterHashOptions:
+                                description: QueryParameterHashOptions should be set
+                                  when request query parameter hash based load balancing
+                                  is desired. It must be the only hash option field
+                                  set, otherwise this request hash policy object will
+                                  be ignored.
+                                properties:
+                                  parameterName:
+                                    description: ParameterName is the name of the HTTP
+                                      request query parameter that will be used to calculate
+                                      the hash key. If the query parameter specified
+                                      is not present on a request, no hash will be produced.
+                                    minLength: 1
+                                    type: string
+                                type: object
+                              terminal:
+                                description: Terminal is a flag that allows for short-circuiting
+                                  computing of a hash for a given request. If set to
+                                  true, and the request attribute specified in the attribute
+                                  hash options is present, no further hash policies
+                                  will be used to calculate a hash for the request.
+                                type: boolean
+                            type: object
+                          type: array
+                        strategy:
+                          description: Strategy specifies the policy used to balance
+                            requests across the pool of backend pods. Valid policy names
+                            are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Cookie`,
+                            and `RequestHash`. If an unknown strategy name is specified
+                            or no policy is supplied, the default `RoundRobin` policy
+                            is used.
+                          type: string
+                      type: object
+                    services:
+                      description: Services are the services to proxy traffic
+                      items:
+                        description: Service defines an Kubernetes Service to proxy
+                          traffic.
+                        properties:
+                          cookieRewritePolicies:
+                            description: The policies for rewriting Set-Cookie header
+                              attributes.
+                            items:
+                              properties:
+                                domainRewrite:
+                                  description: DomainRewrite enables rewriting the Set-Cookie
+                                    Domain element. If not set, Domain will not be rewritten.
+                                  properties:
+                                    value:
+                                      description: Value is the value to rewrite the
+                                        Domain attribute to. For now this is required.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                  required:
+                                    - value
+                                  type: object
+                                name:
+                                  description: Name is the name of the cookie for which
+                                    attributes will be rewritten.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                  type: string
+                                pathRewrite:
+                                  description: PathRewrite enables rewriting the Set-Cookie
+                                    Path element. If not set, Path will not be rewritten.
+                                  properties:
+                                    value:
+                                      description: Value is the value to rewrite the
+                                        Path attribute to. For now this is required.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                      type: string
+                                  required:
+                                    - value
+                                  type: object
+                                sameSite:
+                                  description: SameSite enables rewriting the Set-Cookie
+                                    SameSite element. If not set, SameSite attribute
+                                    will not be rewritten.
+                                  enum:
+                                    - Strict
+                                    - Lax
+                                    - None
+                                  type: string
+                                secure:
+                                  description: Secure enables rewriting the Set-Cookie
+                                    Secure element. If not set, Secure attribute will
+                                    not be rewritten.
+                                  type: boolean
+                              required:
+                                - name
+                              type: object
+                            type: array
+                          healthPort:
+                            description: HealthPort is the port for this service healthcheck.
+                              If not specified, Port is used for service healthchecks.
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          mirror:
+                            description: 'If Mirror is true the Service will receive
+                            a read only mirror of the traffic for this route. If Mirror
+                            is true, then fractional mirroring can be enabled by optionally
+                            setting the Weight field. Legal values for Weight are
+                            1-100. Omitting the Weight field will result in 100% mirroring.
+                            NOTE: Setting Weight explicitly to 0 will unexpectedly
+                            result in 100% traffic mirroring. This occurs since we
+                            cannot distinguish omitted fields from those explicitly
+                            set to their default values'
+                            type: boolean
+                          name:
+                            description: Name is the name of Kubernetes service to proxy
+                              traffic. Names defined here will be used to look up corresponding
+                              endpoints which contain the ips to route.
+                            type: string
+                          port:
+                            description: Port (defined as Integer) to proxy traffic
+                              to since a service can have multiple defined.
+                            exclusiveMaximum: true
+                            maximum: 65536
+                            minimum: 1
+                            type: integer
+                          protocol:
+                            description: Protocol may be used to specify (or override)
+                              the protocol used to reach this Service. Values may be
+                              tls, h2, h2c. If omitted, protocol-selection falls back
+                              on Service annotations.
+                            enum:
+                              - h2
+                              - h2c
+                              - tls
+                            type: string
+                          requestHeadersPolicy:
+                            description: The policy for managing request headers during
+                              proxying.
+                            properties:
+                              remove:
+                                description: Remove specifies a list of HTTP header
+                                  names to remove.
+                                items:
+                                  type: string
+                                type: array
+                              set:
+                                description: Set specifies a list of HTTP header values
+                                  that will be set in the HTTP header. If the header
+                                  does not exist it will be added, otherwise it will
+                                  be overwritten with the new value.
+                                items:
+                                  description: HeaderValue represents a header name/value
+                                    pair
+                                  properties:
+                                    name:
+                                      description: Name represents a key of a header
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: Value represents the value of a header
+                                        specified by a key
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                    - name
+                                    - value
+                                  type: object
+                                type: array
+                            type: object
+                          responseHeadersPolicy:
+                            description: The policy for managing response headers during
+                              proxying. Rewriting the 'Host' header is not supported.
+                            properties:
+                              remove:
+                                description: Remove specifies a list of HTTP header
+                                  names to remove.
+                                items:
+                                  type: string
+                                type: array
+                              set:
+                                description: Set specifies a list of HTTP header values
+                                  that will be set in the HTTP header. If the header
+                                  does not exist it will be added, otherwise it will
+                                  be overwritten with the new value.
+                                items:
+                                  description: HeaderValue represents a header name/value
+                                    pair
+                                  properties:
+                                    name:
+                                      description: Name represents a key of a header
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: Value represents the value of a header
+                                        specified by a key
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                    - name
+                                    - value
+                                  type: object
+                                type: array
+                            type: object
+                          slowStartPolicy:
+                            description: Slow start will gradually increase amount of
+                              traffic to a newly added endpoint.
+                            properties:
+                              aggression:
+                                default: "1.0"
+                                description: "The speed of traffic increase over the
+                                slow start window. Defaults to 1.0, so that endpoint
+                                would get linearly increasing amount of traffic. When
+                                increasing the value for this parameter, the speed
+                                of traffic ramp-up increases non-linearly. The value
+                                of aggression parameter should be greater than 0.0.
+                                \n More info: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/slow_start"
+                                pattern: ^([0-9]+([.][0-9]+)?|[.][0-9]+)$
+                                type: string
+                              minWeightPercent:
+                                default: 10
+                                description: The minimum or starting percentage of traffic
+                                  to send to new endpoints. A non-zero value helps avoid
+                                  a too small initial weight, which may cause endpoints
+                                  in slow start mode to receive no traffic in the beginning
+                                  of the slow start window. If not specified, the default
+                                  is 10%.
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
+                              window:
+                                description: The duration of slow start window. Duration
+                                  is expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                                  Valid time units are "ns", "us" (or "µs"), "ms", "s",
+                                  "m", "h".
+                                pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+)$
+                                type: string
+                            required:
+                              - window
+                            type: object
+                          validation:
+                            description: UpstreamValidation defines how to verify the
+                              backend service's certificate
+                            properties:
+                              caSecret:
+                                description: Name or namespaced name of the Kubernetes
+                                  secret used to validate the certificate presented
+                                  by the backend. The secret must contain key named
+                                  ca.crt. The name can be optionally prefixed with namespace
+                                  "namespace/name". When cross-namespace reference is
+                                  used, TLSCertificateDelegation resource must exist
+                                  in the namespace to grant access to the secret.
+                                type: string
+                              subjectName:
+                                description: Key which is expected to be present in
+                                  the 'subjectAltName' of the presented certificate.
+                                type: string
+                            required:
+                              - caSecret
+                              - subjectName
+                            type: object
+                          weight:
+                            description: Weight defines percentage of traffic to balance
+                              traffic
+                            format: int64
+                            minimum: 0
+                            type: integer
+                        required:
+                          - name
+                          - port
+                        type: object
+                      type: array
+                  type: object
+                virtualhost:
+                  description: Virtualhost appears at most once. If it is present, the
+                    object is considered to be a "root" HTTPProxy.
+                  properties:
+                    authorization:
+                      description: This field configures an extension service to perform
+                        authorization for this virtual host. Authorization can only
+                        be configured on virtual hosts that have TLS enabled. If the
+                        TLS configuration requires client certificate validation, the
+                        client certificate is always included in the authentication
+                        check request.
+                      properties:
+                        authPolicy:
+                          description: AuthPolicy sets a default authorization policy
+                            for client requests. This policy will be used unless overridden
+                            by individual routes.
+                          properties:
+                            context:
+                              additionalProperties:
+                                type: string
+                              description: Context is a set of key/value pairs that
+                                are sent to the authentication server in the check request.
+                                If a context is provided at an enclosing scope, the
+                                entries are merged such that the inner scope overrides
+                                matching keys from the outer scope.
+                              type: object
+                            disabled:
+                              description: When true, this field disables client request
+                                authentication for the scope of the policy.
+                              type: boolean
+                          type: object
+                        extensionRef:
+                          description: ExtensionServiceRef specifies the extension resource
+                            that will authorize client requests.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent. If this field
+                                is not specified, the default "projectcontour.io/v1alpha1"
+                                will be used
+                              minLength: 1
+                              type: string
+                            name:
+                              description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: "Namespace of the referent. If this field
+                              is not specifies, the namespace of the resource that
+                              targets the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                              minLength: 1
+                              type: string
+                          type: object
+                        failOpen:
+                          description: If FailOpen is true, the client request is forwarded
+                            to the upstream service even if the authorization server
+                            fails to respond. This field should not be set in most cases.
+                            It is intended for use only while migrating applications
+                            from internal authorization to Contour external authorization.
+                          type: boolean
+                        responseTimeout:
+                          description: ResponseTimeout configures maximum time to wait
+                            for a check response from the authorization server. Timeout
+                            durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                            Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+                            "h". The string "infinity" is also a valid input and specifies
+                            no timeout.
+                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                          type: string
+                        withRequestBody:
+                          description: WithRequestBody specifies configuration for sending
+                            the client request's body to authorization server.
+                          properties:
+                            allowPartialMessage:
+                              description: If AllowPartialMessage is true, then Envoy
+                                will buffer the body until MaxRequestBytes are reached.
+                              type: boolean
+                            maxRequestBytes:
+                              default: 1024
+                              description: MaxRequestBytes sets the maximum size of
+                                message body ExtAuthz filter will hold in-memory.
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            packAsBytes:
+                              description: If PackAsBytes is true, the body sent to
+                                Authorization Server is in raw bytes.
+                              type: boolean
+                          type: object
+                      type: object
+                    corsPolicy:
+                      description: Specifies the cross-origin policy to apply to the
+                        VirtualHost.
+                      properties:
+                        allowCredentials:
+                          description: Specifies whether the resource allows credentials.
+                          type: boolean
+                        allowHeaders:
+                          description: AllowHeaders specifies the content for the *access-control-allow-headers*
+                            header.
+                          items:
+                            description: CORSHeaderValue specifies the value of the
+                              string headers returned by a cross-domain request.
+                            pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
+                            type: string
+                          minItems: 1
+                          type: array
+                        allowMethods:
+                          description: AllowMethods specifies the content for the *access-control-allow-methods*
+                            header.
+                          items:
+                            description: CORSHeaderValue specifies the value of the
+                              string headers returned by a cross-domain request.
+                            pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
+                            type: string
+                          minItems: 1
+                          type: array
+                        allowOrigin:
+                          description: AllowOrigin specifies the origins that will be
+                            allowed to do CORS requests. Allowed values include "*"
+                            which signifies any origin is allowed, an exact origin of
+                            the form "scheme://host[:port]" (where port is optional),
+                            or a valid regex pattern. Note that regex patterns are validated
+                            and a simple "glob" pattern (e.g. *.foo.com) will be rejected
+                            or produce unexpected matches when applied as a regex.
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                        allowPrivateNetwork:
+                          description: AllowPrivateNetwork specifies whether to allow
+                            private network requests. See https://developer.chrome.com/blog/private-network-access-preflight.
+                          type: boolean
+                        exposeHeaders:
+                          description: ExposeHeaders Specifies the content for the *access-control-expose-headers*
+                            header.
+                          items:
+                            description: CORSHeaderValue specifies the value of the
+                              string headers returned by a cross-domain request.
+                            pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
+                            type: string
+                          minItems: 1
+                          type: array
+                        maxAge:
+                          description: MaxAge indicates for how long the results of
+                            a preflight request can be cached. MaxAge durations are
+                            expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                            Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+                            "h". Only positive values are allowed while 0 disables the
+                            cache requiring a preflight OPTIONS check for all cross-origin
+                            requests.
+                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|0)$
+                          type: string
+                      required:
+                        - allowMethods
+                        - allowOrigin
+                      type: object
+                    fqdn:
+                      description: The fully qualified domain name of the root of the
+                        ingress tree all leaves of the DAG rooted at this object relate
+                        to the fqdn.
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    ipAllowPolicy:
+                      description: IPAllowFilterPolicy is a list of ipv4/6 filter rules
+                        for which matching requests should be allowed. All other requests
+                        will be denied. Only one of IPAllowFilterPolicy and IPDenyFilterPolicy
+                        can be defined. The rules defined here may be overridden in
+                        a Route.
+                      items:
+                        properties:
+                          cidr:
+                            description: CIDR is a CIDR block of ipv4 or ipv6 addresses
+                              to filter on. This can also be a bare IP address (without
+                              a mask) to filter on exactly one address.
+                            type: string
+                          source:
+                            description: 'Source indicates how to determine the ip address
+                            to filter on, and can be one of two values: - `Remote`
+                            filters on the ip address of the client, accounting for
+                            PROXY and X-Forwarded-For as needed. - `Peer` filters
+                            on the ip of the network request, ignoring PROXY and X-Forwarded-For.'
+                            enum:
+                              - Peer
+                              - Remote
+                            type: string
+                        required:
+                          - cidr
+                          - source
+                        type: object
+                      type: array
+                    ipDenyPolicy:
+                      description: IPDenyFilterPolicy is a list of ipv4/6 filter rules
+                        for which matching requests should be denied. All other requests
+                        will be allowed. Only one of IPAllowFilterPolicy and IPDenyFilterPolicy
+                        can be defined. The rules defined here may be overridden in
+                        a Route.
+                      items:
+                        properties:
+                          cidr:
+                            description: CIDR is a CIDR block of ipv4 or ipv6 addresses
+                              to filter on. This can also be a bare IP address (without
+                              a mask) to filter on exactly one address.
+                            type: string
+                          source:
+                            description: 'Source indicates how to determine the ip address
+                            to filter on, and can be one of two values: - `Remote`
+                            filters on the ip address of the client, accounting for
+                            PROXY and X-Forwarded-For as needed. - `Peer` filters
+                            on the ip of the network request, ignoring PROXY and X-Forwarded-For.'
+                            enum:
+                              - Peer
+                              - Remote
+                            type: string
+                        required:
+                          - cidr
+                          - source
+                        type: object
+                      type: array
+                    jwtProviders:
+                      description: Providers to use for verifying JSON Web Tokens (JWTs)
+                        on the virtual host.
+                      items:
+                        description: JWTProvider defines how to verify JWTs on requests.
+                        properties:
+                          audiences:
+                            description: Audiences that JWTs are allowed to have in
+                              the "aud" field. If not provided, JWT audiences are not
+                              checked.
+                            items:
+                              type: string
+                            type: array
+                          default:
+                            description: Whether the provider should apply to all routes
+                              in the HTTPProxy/its includes by default. At most one
+                              provider can be marked as the default. If no provider
+                              is marked as the default, individual routes must explicitly
+                              identify the provider they require.
+                            type: boolean
+                          forwardJWT:
+                            description: Whether the JWT should be forwarded to the
+                              backend service after successful verification. By default,
+                              the JWT is not forwarded.
+                            type: boolean
+                          issuer:
+                            description: Issuer that JWTs are required to have in the
+                              "iss" field. If not provided, JWT issuers are not checked.
+                            type: string
+                          name:
+                            description: Unique name for the provider.
+                            minLength: 1
+                            type: string
+                          remoteJWKS:
+                            description: Remote JWKS to use for verifying JWT signatures.
+                            properties:
+                              cacheDuration:
+                                description: How long to cache the JWKS locally. If
+                                  not specified, Envoy's default of 5m applies.
+                                pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+)$
+                                type: string
+                              dnsLookupFamily:
+                                description: "The DNS IP address resolution policy for
+                                the JWKS URI. When configured as \"v4\", the DNS resolver
+                                will only perform a lookup for addresses in the IPv4
+                                family. If \"v6\" is configured, the DNS resolver
+                                will only perform a lookup for addresses in the IPv6
+                                family. If \"all\" is configured, the DNS resolver
+                                will perform a lookup for addresses in both the IPv4
+                                and IPv6 family. If \"auto\" is configured, the DNS
+                                resolver will first perform a lookup for addresses
+                                in the IPv6 family and fallback to a lookup for addresses
+                                in the IPv4 family. If not specified, the Contour-wide
+                                setting defined in the config file or ContourConfiguration
+                                applies (defaults to \"auto\"). \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                                for more information."
+                                enum:
+                                  - auto
+                                  - v4
+                                  - v6
+                                type: string
+                              timeout:
+                                description: How long to wait for a response from the
+                                  URI. If not specified, a default of 1s applies.
+                                pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+)$
+                                type: string
+                              uri:
+                                description: The URI for the JWKS.
+                                minLength: 1
+                                type: string
+                              validation:
+                                description: UpstreamValidation defines how to verify
+                                  the JWKS's TLS certificate.
+                                properties:
+                                  caSecret:
+                                    description: Name or namespaced name of the Kubernetes
+                                      secret used to validate the certificate presented
+                                      by the backend. The secret must contain key named
+                                      ca.crt. The name can be optionally prefixed with
+                                      namespace "namespace/name". When cross-namespace
+                                      reference is used, TLSCertificateDelegation resource
+                                      must exist in the namespace to grant access to
+                                      the secret.
+                                    type: string
+                                  subjectName:
+                                    description: Key which is expected to be present
+                                      in the 'subjectAltName' of the presented certificate.
+                                    type: string
+                                required:
+                                  - caSecret
+                                  - subjectName
+                                type: object
+                            required:
+                              - uri
+                            type: object
+                        required:
+                          - name
+                          - remoteJWKS
+                        type: object
+                      type: array
+                    rateLimitPolicy:
+                      description: The policy for rate limiting on the virtual host.
+                      properties:
+                        global:
+                          description: Global defines global rate limiting parameters,
+                            i.e. parameters defining descriptors that are sent to an
+                            external rate limit service (RLS) for a rate limit decision
+                            on each request.
+                          properties:
+                            descriptors:
+                              description: Descriptors defines the list of descriptors
+                                that will be generated and sent to the rate limit service.
+                                Each descriptor contains 1+ key-value pair entries.
+                              items:
+                                description: RateLimitDescriptor defines a list of key-value
+                                  pair generators.
+                                properties:
+                                  entries:
+                                    description: Entries is the list of key-value pair
+                                      generators.
+                                    items:
+                                      description: RateLimitDescriptorEntry is a key-value
+                                        pair generator. Exactly one field on this struct
+                                        must be non-nil.
+                                      properties:
+                                        genericKey:
+                                          description: GenericKey defines a descriptor
+                                            entry with a static key and value.
+                                          properties:
+                                            key:
+                                              description: Key defines the key of the
+                                                descriptor entry. If not set, the key
+                                                is set to "generic_key".
+                                              type: string
+                                            value:
+                                              description: Value defines the value of
+                                                the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                        remoteAddress:
+                                          description: RemoteAddress defines a descriptor
+                                            entry with a key of "remote_address" and
+                                            a value equal to the client's IP address
+                                            (from x-forwarded-for).
+                                          type: object
+                                        requestHeader:
+                                          description: RequestHeader defines a descriptor
+                                            entry that's populated only if a given header
+                                            is present on the request. The descriptor
+                                            key is static, and the descriptor value
+                                            is equal to the value of the header.
+                                          properties:
+                                            descriptorKey:
+                                              description: DescriptorKey defines the
+                                                key to use on the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                            headerName:
+                                              description: HeaderName defines the name
+                                                of the header to look for on the request.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                        requestHeaderValueMatch:
+                                          description: RequestHeaderValueMatch defines
+                                            a descriptor entry that's populated if the
+                                            request's headers match a set of 1+ match
+                                            criteria. The descriptor key is "header_match",
+                                            and the descriptor value is static.
+                                          properties:
+                                            expectMatch:
+                                              default: true
+                                              description: ExpectMatch defines whether
+                                                the request must positively match the
+                                                match criteria in order to generate
+                                                a descriptor entry (i.e. true), or not
+                                                match the match criteria in order to
+                                                generate a descriptor entry (i.e. false).
+                                                The default is true.
+                                              type: boolean
+                                            headers:
+                                              description: Headers is a list of 1+ match
+                                                criteria to apply against the request
+                                                to determine whether to populate the
+                                                descriptor entry or not.
+                                              items:
+                                                description: HeaderMatchCondition specifies
+                                                  how to conditionally match against
+                                                  HTTP headers. The Name field is required,
+                                                  but only one of the remaining fields
+                                                  should be be provided.
+                                                properties:
+                                                  contains:
+                                                    description: Contains specifies
+                                                      a substring that must be present
+                                                      in the header value.
+                                                    type: string
+                                                  exact:
+                                                    description: Exact specifies a string
+                                                      that the header value must be
+                                                      equal to.
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name of
+                                                      the header to match against. Name
+                                                      is required. Header names are
+                                                      case insensitive.
+                                                    type: string
+                                                  notcontains:
+                                                    description: NotContains specifies
+                                                      a substring that must not be present
+                                                      in the header value.
+                                                    type: string
+                                                  notexact:
+                                                    description: NoExact specifies a
+                                                      string that the header value must
+                                                      not be equal to. The condition
+                                                      is true if the header has any
+                                                      other value.
+                                                    type: string
+                                                  notpresent:
+                                                    description: NotPresent specifies
+                                                      that condition is true when the
+                                                      named header is not present. Note
+                                                      that setting NotPresent to false
+                                                      does not make the condition true
+                                                      if the named header is present.
+                                                    type: boolean
+                                                  present:
+                                                    description: Present specifies that
+                                                      condition is true when the named
+                                                      header is present, regardless
+                                                      of its value. Note that setting
+                                                      Present to false does not make
+                                                      the condition true if the named
+                                                      header is absent.
+                                                    type: boolean
+                                                  regex:
+                                                    description: Regex specifies a regular
+                                                      expression pattern that must match
+                                                      the header value.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              minItems: 1
+                                              type: array
+                                            value:
+                                              description: Value defines the value of
+                                                the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                      type: object
+                                    minItems: 1
+                                    type: array
+                                type: object
+                              minItems: 1
+                              type: array
+                            disabled:
+                              description: Disabled configures the HTTPProxy to not
+                                use the default global rate limit policy defined by
+                                the Contour configuration.
+                              type: boolean
+                          type: object
+                        local:
+                          description: Local defines local rate limiting parameters,
+                            i.e. parameters for rate limiting that occurs within each
+                            Envoy pod as requests are handled.
+                          properties:
+                            burst:
+                              description: Burst defines the number of requests above
+                                the requests per unit that should be allowed within
+                                a short period of time.
+                              format: int32
+                              type: integer
+                            requests:
+                              description: Requests defines how many requests per unit
+                                of time should be allowed before rate limiting occurs.
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            responseHeadersToAdd:
+                              description: ResponseHeadersToAdd is an optional list
+                                of response headers to set when a request is rate-limited.
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                            responseStatusCode:
+                              description: ResponseStatusCode is the HTTP status code
+                                to use for responses to rate-limited requests. Codes
+                                must be in the 400-599 range (inclusive). If not specified,
+                                the Envoy default of 429 (Too Many Requests) is used.
+                              format: int32
+                              maximum: 599
+                              minimum: 400
+                              type: integer
+                            unit:
+                              description: Unit defines the period of time within which
+                                requests over the limit will be rate limited. Valid
+                                values are "second", "minute" and "hour".
+                              enum:
+                                - second
+                                - minute
+                                - hour
+                              type: string
+                          required:
+                            - requests
+                            - unit
+                          type: object
+                      type: object
+                    tls:
+                      description: If present the fields describes TLS properties of
+                        the virtual host. The SNI names that will be matched on are
+                        described in fqdn, the tls.secretName secret must contain a
+                        certificate that itself contains a name that matches the FQDN.
+                      properties:
+                        clientValidation:
+                          description: "ClientValidation defines how to verify the client
+                          certificate when an external client establishes a TLS connection
+                          to Envoy. \n This setting: \n 1. Enables TLS client certificate
+                          validation. 2. Specifies how the client certificate will
+                          be validated (i.e. validation required or skipped). \n Note:
+                          Setting client certificate validation to be skipped should
+                          be only used in conjunction with an external authorization
+                          server that performs client validation as Contour will ensure
+                          client certificates are passed along."
+                          properties:
+                            caSecret:
+                              description: Name of a Kubernetes secret that contains
+                                a CA certificate bundle. The secret must contain key
+                                named ca.crt. The client certificate must validate against
+                                the certificates in the bundle. If specified and SkipClientCertValidation
+                                is true, client certificates will be required on requests.
+                                The name can be optionally prefixed with namespace "namespace/name".
+                                When cross-namespace reference is used, TLSCertificateDelegation
+                                resource must exist in the namespace to grant access
+                                to the secret.
+                              minLength: 1
+                              type: string
+                            crlOnlyVerifyLeafCert:
+                              description: If this option is set to true, only the certificate
+                                at the end of the certificate chain will be subject
+                                to validation by CRL.
+                              type: boolean
+                            crlSecret:
+                              description: Name of a Kubernetes opaque secret that contains
+                                a concatenated list of PEM encoded CRLs. The secret
+                                must contain key named crl.pem. This field will be used
+                                to verify that a client certificate has not been revoked.
+                                CRLs must be available from all CAs, unless crlOnlyVerifyLeafCert
+                                is true. Large CRL lists are not supported since individual
+                                secrets are limited to 1MiB in size. The name can be
+                                optionally prefixed with namespace "namespace/name".
+                                When cross-namespace reference is used, TLSCertificateDelegation
+                                resource must exist in the namespace to grant access
+                                to the secret.
+                              minLength: 1
+                              type: string
+                            forwardClientCertificate:
+                              description: ForwardClientCertificate adds the selected
+                                data from the passed client TLS certificate to the x-forwarded-client-cert
+                                header.
+                              properties:
+                                cert:
+                                  description: Client cert in URL encoded PEM format.
+                                  type: boolean
+                                chain:
+                                  description: Client cert chain (including the leaf
+                                    cert) in URL encoded PEM format.
+                                  type: boolean
+                                dns:
+                                  description: DNS type Subject Alternative Names of
+                                    the client cert.
+                                  type: boolean
+                                subject:
+                                  description: Subject of the client cert.
+                                  type: boolean
+                                uri:
+                                  description: URI type Subject Alternative Name of
+                                    the client cert.
+                                  type: boolean
+                              type: object
+                            optionalClientCertificate:
+                              description: OptionalClientCertificate when set to true
+                                will request a client certificate but allow the connection
+                                to continue if the client does not provide one. If a
+                                client certificate is sent, it will be verified according
+                                to the other properties, which includes disabling validation
+                                if SkipClientCertValidation is set. Defaults to false.
+                              type: boolean
+                            skipClientCertValidation:
+                              description: SkipClientCertValidation disables downstream
+                                client certificate validation. Defaults to false. This
+                                field is intended to be used in conjunction with external
+                                authorization in order to enable the external authorization
+                                server to validate client certificates. When this field
+                                is set to true, client certificates are requested but
+                                not verified by Envoy. If CACertificate is specified,
+                                client certificates are required on requests, but not
+                                verified. If external authorization is in use, they
+                                are presented to the external authorization server.
+                              type: boolean
+                          type: object
+                        enableFallbackCertificate:
+                          description: EnableFallbackCertificate defines if the vhost
+                            should allow a default certificate to be applied which handles
+                            all requests which don't match the SNI defined in this vhost.
+                          type: boolean
+                        minimumProtocolVersion:
+                          description: MinimumProtocolVersion is the minimum TLS version
+                            this vhost should negotiate. Valid options are `1.2` (default)
+                            and `1.3`. Any other value defaults to TLS 1.2.
+                          type: string
+                        passthrough:
+                          description: Passthrough defines whether the encrypted TLS
+                            handshake will be passed through to the backing cluster.
+                            Either Passthrough or SecretName must be specified, but
+                            not both.
+                          type: boolean
+                        secretName:
+                          description: SecretName is the name of a TLS secret. Either
+                            SecretName or Passthrough must be specified, but not both.
+                            If specified, the named secret must contain a matching certificate
+                            for the virtual host's FQDN. The name can be optionally
+                            prefixed with namespace "namespace/name". When cross-namespace
+                            reference is used, TLSCertificateDelegation resource must
+                            exist in the namespace to grant access to the secret.
+                          type: string
+                      type: object
+                  required:
+                    - fqdn
+                  type: object
+              type: object
+            status:
+              default:
+                currentStatus: NotReconciled
+                description: Waiting for controller
+              description: Status is a container for computed information about the
+                HTTPProxy.
+              properties:
+                conditions:
+                  description: "Conditions contains information about the current status
+                  of the HTTPProxy, in an upstream-friendly container. \n Contour
+                  will update a single condition, `Valid`, that is in normal-true
+                  polarity. That is, when `currentStatus` is `valid`, the `Valid`
+                  condition will be `status: true`, and vice versa. \n Contour will
+                  leave untouched any other Conditions set in this block, in case
+                  some other controller wants to add a Condition. \n If you are another
+                  controller owner and wish to add a condition, you *should* namespace
+                  your condition with a label, like `controller.domain.com/ConditionName`."
+                  items:
+                    description: "DetailedCondition is an extension of the normal Kubernetes
+                    conditions, with two extra fields to hold sub-conditions, which
+                    provide more detailed reasons for the state (True or False) of
+                    the condition. \n `errors` holds information about sub-conditions
+                    which are fatal to that condition and render its state False.
+                    \n `warnings` holds information about sub-conditions which are
+                    not fatal to that condition and do not force the state to be False.
+                    \n Remember that Conditions have a type, a status, and a reason.
+                    \n The type is the type of the condition, the most important one
+                    in this CRD set is `Valid`. `Valid` is a positive-polarity condition:
+                    when it is `status: true` there are no problems. \n In more detail,
+                    `status: true` means that the object is has been ingested into
+                    Contour with no errors. `warnings` may still be present, and will
+                    be indicated in the Reason field. There must be zero entries in
+                    the `errors` slice in this case. \n `Valid`, `status: false` means
+                    that the object has had one or more fatal errors during processing
+                    into Contour. The details of the errors will be present under
+                    the `errors` field. There must be at least one error in the `errors`
+                    slice if `status` is `false`. \n For DetailedConditions of types
+                    other than `Valid`, the Condition must be in the negative polarity.
+                    When they have `status` `true`, there is an error. There must
+                    be at least one entry in the `errors` Subcondition slice. When
+                    they have `status` `false`, there are no serious errors, and there
+                    must be zero entries in the `errors` slice. In either case, there
+                    may be entries in the `warnings` slice. \n Regardless of the polarity,
+                    the `reason` and `message` fields must be updated with either
+                    the detail of the reason (if there is one and only one entry in
+                    total across both the `errors` and `warnings` slices), or `MultipleReasons`
+                    if there is more than one entry."
+                    properties:
+                      errors:
+                        description: "Errors contains a slice of relevant error subconditions
+                        for this object. \n Subconditions are expected to appear when
+                        relevant (when there is a error), and disappear when not relevant.
+                        An empty slice here indicates no errors."
+                        items:
+                          description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition
+                          transitioned from one status to another. This should be when
+                          the underlying condition changed.  If that is not known, then
+                          using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating
+                          details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if .metadata.generation
+                          is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition. Producers
+                          of specific condition types may define expected values and
+                          meanings for this field, and whether the values are considered
+                          a guaranteed API. The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          --- Many .condition.type values are consistent across resources
+                          like Available, but because arbitrary conditions can be useful
+                          (see .node.status.conditions), the ability to deconflict is
+                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                      warnings:
+                        description: "Warnings contains a slice of relevant warning
+                        subconditions for this object. \n Subconditions are expected
+                        to appear when relevant (when there is a warning), and disappear
+                        when not relevant. An empty slice here indicates no warnings."
+                        items:
+                          description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                currentStatus:
+                  type: string
+                description:
+                  type: string
+                loadBalancer:
+                  description: LoadBalancer contains the current status of the load
+                    balancer.
+                  properties:
+                    ingress:
+                      description: Ingress is a list containing ingress points for the
+                        load-balancer. Traffic intended for the service should be sent
+                        to these ingress points.
+                      items:
+                        description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
+                        properties:
+                          hostname:
+                            description: Hostname is set for load-balancer ingress points
+                              that are DNS based (typically AWS load-balancers)
+                            type: string
+                          ip:
+                            description: IP is set for load-balancer ingress points
+                              that are IP based (typically GCE or OpenStack load-balancers)
+                            type: string
+                          ports:
+                            description: Ports is a list of records of service ports
+                              If used, every port defined in the service should have
+                              an entry in it
+                            items:
+                              properties:
+                                error:
+                                  description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use CamelCase names - cloud provider specific error
+                                  values must have names that comply with the format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                  maxLength: 316
+                                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                  type: string
+                                port:
+                                  description: Port is the port number of the service
+                                    port of which status is recorded here
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                  type: string
+                              required:
+                                - port
+                                - protocol
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: tlscertificatedelegations.projectcontour.io
+spec:
+  preserveUnknownFields: false
+  group: projectcontour.io
+  names:
+    kind: TLSCertificateDelegation
+    listKind: TLSCertificateDelegationList
+    plural: tlscertificatedelegations
+    shortNames:
+      - tlscerts
+    singular: tlscertificatedelegation
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: TLSCertificateDelegation is an TLS Certificate Delegation CRD
+            specification. See design/tls-certificate-delegation.md for details.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TLSCertificateDelegationSpec defines the spec of the CRD
+              properties:
+                delegations:
+                  items:
+                    description: CertificateDelegation maps the authority to reference
+                      a secret in the current namespace to a set of namespaces.
+                    properties:
+                      secretName:
+                        description: required, the name of a secret in the current namespace.
+                        type: string
+                      targetNamespaces:
+                        description: required, the namespaces the authority to reference
+                          the secret will be delegated to. If TargetNamespaces is nil
+                          or empty, the CertificateDelegation' is ignored. If the TargetNamespace
+                          list contains the character, "*" the secret will be delegated
+                          to all namespaces.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - secretName
+                      - targetNamespaces
+                    type: object
+                  type: array
+              required:
+                - delegations
+              type: object
+            status:
+              description: TLSCertificateDelegationStatus allows for the status of the
+                delegation to be presented to the user.
+              properties:
+                conditions:
+                  description: "Conditions contains information about the current status
+                  of the HTTPProxy, in an upstream-friendly container. \n Contour
+                  will update a single condition, `Valid`, that is in normal-true
+                  polarity. That is, when `currentStatus` is `valid`, the `Valid`
+                  condition will be `status: true`, and vice versa. \n Contour will
+                  leave untouched any other Conditions set in this block, in case
+                  some other controller wants to add a Condition. \n If you are another
+                  controller owner and wish to add a condition, you *should* namespace
+                  your condition with a label, like `controller.domain.com\\ConditionName`."
+                  items:
+                    description: "DetailedCondition is an extension of the normal Kubernetes
+                    conditions, with two extra fields to hold sub-conditions, which
+                    provide more detailed reasons for the state (True or False) of
+                    the condition. \n `errors` holds information about sub-conditions
+                    which are fatal to that condition and render its state False.
+                    \n `warnings` holds information about sub-conditions which are
+                    not fatal to that condition and do not force the state to be False.
+                    \n Remember that Conditions have a type, a status, and a reason.
+                    \n The type is the type of the condition, the most important one
+                    in this CRD set is `Valid`. `Valid` is a positive-polarity condition:
+                    when it is `status: true` there are no problems. \n In more detail,
+                    `status: true` means that the object is has been ingested into
+                    Contour with no errors. `warnings` may still be present, and will
+                    be indicated in the Reason field. There must be zero entries in
+                    the `errors` slice in this case. \n `Valid`, `status: false` means
+                    that the object has had one or more fatal errors during processing
+                    into Contour. The details of the errors will be present under
+                    the `errors` field. There must be at least one error in the `errors`
+                    slice if `status` is `false`. \n For DetailedConditions of types
+                    other than `Valid`, the Condition must be in the negative polarity.
+                    When they have `status` `true`, there is an error. There must
+                    be at least one entry in the `errors` Subcondition slice. When
+                    they have `status` `false`, there are no serious errors, and there
+                    must be zero entries in the `errors` slice. In either case, there
+                    may be entries in the `warnings` slice. \n Regardless of the polarity,
+                    the `reason` and `message` fields must be updated with either
+                    the detail of the reason (if there is one and only one entry in
+                    total across both the `errors` and `warnings` slices), or `MultipleReasons`
+                    if there is more than one entry."
+                    properties:
+                      errors:
+                        description: "Errors contains a slice of relevant error subconditions
+                        for this object. \n Subconditions are expected to appear when
+                        relevant (when there is a error), and disappear when not relevant.
+                        An empty slice here indicates no errors."
+                        items:
+                          description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition
+                          transitioned from one status to another. This should be when
+                          the underlying condition changed.  If that is not known, then
+                          using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating
+                          details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if .metadata.generation
+                          is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition. Producers
+                          of specific condition types may define expected values and
+                          meanings for this field, and whether the values are considered
+                          a guaranteed API. The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          --- Many .condition.type values are consistent across resources
+                          like Available, but because arbitrary conditions can be useful
+                          (see .node.status.conditions), the ability to deconflict is
+                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                      warnings:
+                        description: "Warnings contains a slice of relevant warning
+                        subconditions for this object. \n Subconditions are expected
+                        to appear when relevant (when there is a warning), and disappear
+                        when not relevant. An empty slice here indicates no warnings."
+                        items:
+                          description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/external-crd/route.openshift.io_routes.yaml
+++ b/config/external-crd/route.openshift.io_routes.yaml
@@ -1,0 +1,281 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1228
+  name: routes.route.openshift.io
+spec:
+  group: route.openshift.io
+  names:
+    kind: Route
+    plural: routes
+    singular: route
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.ingress[0].host
+          name: Host
+          type: string
+        - jsonPath: .status.ingress[0].conditions[?(@.type=="Admitted")].status
+          name: Admitted
+          type: string
+        - jsonPath: .spec.to.name
+          name: Service
+          type: string
+        - jsonPath: .spec.tls.type
+          name: TLS
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: "A route allows developers to expose services through an HTTP(S) aware load balancing and proxy layer via a public DNS entry. The route may further specify TLS options and a certificate, or specify a public CNAME that the router should also accept for HTTP and HTTPS traffic. An administrator typically configures their router to be visible outside the cluster firewall, and may also add additional security, caching, or traffic controls on the service content. Routers usually talk directly to the service endpoints. \n Once a route is created, the `host` field may not be changed. Generally, routers use the oldest route with a given host when resolving conflicts. \n Routers are subject to additional customization and may support additional controls via the annotations field. \n Because administrators may configure multiple routers, the route status field is used to return information to clients about the names and states of the route under each router. If a client chooses a duplicate name, for instance, the route status conditions are used to indicate the route cannot be chosen. \n To enable HTTP/2 ALPN on a route it requires a custom (non-wildcard) certificate. This prevents connection coalescing by clients, notably web browsers. We do not support HTTP/2 ALPN on routes that use the default certificate because of the risk of connection re-use/coalescing. Routes that do not have their own custom certificate will not be HTTP/2 ALPN-enabled on either the frontend or the backend. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              allOf:
+                - anyOf:
+                    - properties:
+                        path:
+                          maxLength: 0
+                    - properties:
+                        tls:
+                          enum:
+                            - null
+                    - not:
+                        properties:
+                          tls:
+                            properties:
+                              termination:
+                                enum:
+                                  - passthrough
+                - anyOf:
+                    - not:
+                        properties:
+                          host:
+                            maxLength: 0
+                    - not:
+                        properties:
+                          wildcardPolicy:
+                            enum:
+                              - Subdomain
+              description: spec is the desired state of the route
+              properties:
+                alternateBackends:
+                  description: alternateBackends allows up to 3 additional backends to be assigned to the route. Only the Service kind is allowed, and it will be defaulted to Service. Use the weight field in RouteTargetReference object to specify relative preference.
+                  items:
+                    description: RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service' kind is allowed. Use 'weight' field to emphasize one over others.
+                    properties:
+                      kind:
+                        default: Service
+                        description: The kind of target that the route is referring to. Currently, only 'Service' is allowed
+                        enum:
+                          - Service
+                          - ""
+                        type: string
+                      name:
+                        description: name of the service/target that is being referred to. e.g. name of the service
+                        minLength: 1
+                        type: string
+                      weight:
+                        default: 100
+                        description: weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.
+                        format: int32
+                        maximum: 256
+                        minimum: 0
+                        type: integer
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  maxItems: 3
+                  type: array
+                host:
+                  description: host is an alias/DNS that points to the service. Optional. If not specified a route name will typically be automatically chosen. Must follow DNS952 subdomain conventions.
+                  maxLength: 253
+                  pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                  type: string
+                path:
+                  description: path that the router watches for, to route traffic for to the service. Optional
+                  pattern: ^/
+                  type: string
+                port:
+                  description: If specified, the port to be used by the router. Most routers will use all endpoints exposed by the service by default - set this value to instruct routers which port to use.
+                  properties:
+                    targetPort:
+                      allOf:
+                        - not:
+                            enum:
+                              - 0
+                        - not:
+                            enum:
+                              - ""
+                      x-kubernetes-int-or-string: true
+                  required:
+                    - targetPort
+                  type: object
+                subdomain:
+                  description: "subdomain is a DNS subdomain that is requested within the ingress controller's domain (as a subdomain). If host is set this field is ignored. An ingress controller may choose to ignore this suggested name, in which case the controller will report the assigned name in the status.ingress array or refuse to admit the route. If this value is set and the server does not support this field host will be populated automatically. Otherwise host is left empty. The field may have multiple parts separated by a dot, but not all ingress controllers may honor the request. This field may not be changed after creation except by a user with the update routes/custom-host permission. \n Example: subdomain `frontend` automatically receives the router subdomain `apps.mycluster.com` to have a full hostname `frontend.apps.mycluster.com`."
+                  maxLength: 253
+                  pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                  type: string
+                tls:
+                  allOf:
+                    - anyOf:
+                        - properties:
+                            caCertificate:
+                              maxLength: 0
+                            certificate:
+                              maxLength: 0
+                            destinationCACertificate:
+                              maxLength: 0
+                            key:
+                              maxLength: 0
+                        - not:
+                            properties:
+                              termination:
+                                enum:
+                                  - passthrough
+                    - anyOf:
+                        - properties:
+                            destinationCACertificate:
+                              maxLength: 0
+                        - not:
+                            properties:
+                              termination:
+                                enum:
+                                  - edge
+                  description: The tls field provides the ability to configure certificates and termination for the route.
+                  properties:
+                    caCertificate:
+                      description: caCertificate provides the cert authority certificate contents
+                      type: string
+                    certificate:
+                      description: certificate provides certificate contents. This should be a single serving certificate, not a certificate chain. Do not include a CA certificate.
+                      type: string
+                    destinationCACertificate:
+                      description: destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt termination this file should be provided in order to have routers use it for health checks on the secure connection. If this field is not specified, the router may provide its own destination CA and perform hostname validation using the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically verify.
+                      type: string
+                    insecureEdgeTerminationPolicy:
+                      description: "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80. \n * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default). * None - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port."
+                      enum:
+                        - Allow
+                        - None
+                        - Redirect
+                        - ""
+                      type: string
+                    key:
+                      description: key provides key file contents
+                      type: string
+                    termination:
+                      description: "termination indicates termination type. \n * edge - TLS termination is done by the router and http is used to communicate with the backend (default) * passthrough - Traffic is sent straight to the destination without the router providing TLS termination * reencrypt - TLS termination is done by the router and https is used to communicate with the backend"
+                      enum:
+                        - edge
+                        - reencrypt
+                        - passthrough
+                      type: string
+                  required:
+                    - termination
+                  type: object
+                  x-kubernetes-validations:
+                    - message: 'cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow'
+                      rule: 'has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination==''passthrough'') && (self.insecureEdgeTerminationPolicy==''Allow'')) : true'
+                to:
+                  description: to is an object the route should use as the primary backend. Only the Service kind is allowed, and it will be defaulted to Service. If the weight field (0-256 default 100) is set to zero, no traffic will be sent to this backend.
+                  properties:
+                    kind:
+                      default: Service
+                      description: The kind of target that the route is referring to. Currently, only 'Service' is allowed
+                      enum:
+                        - Service
+                        - ""
+                      type: string
+                    name:
+                      description: name of the service/target that is being referred to. e.g. name of the service
+                      minLength: 1
+                      type: string
+                    weight:
+                      default: 100
+                      description: weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.
+                      format: int32
+                      maximum: 256
+                      minimum: 0
+                      type: integer
+                  required:
+                    - kind
+                    - name
+                  type: object
+                wildcardPolicy:
+                  default: None
+                  description: Wildcard policy if any for the route. Currently only 'Subdomain' or 'None' is allowed.
+                  enum:
+                    - None
+                    - Subdomain
+                    - ""
+                  type: string
+              required:
+                - to
+              type: object
+            status:
+              description: status is the current state of the route
+              properties:
+                ingress:
+                  description: ingress describes the places where the route may be exposed. The list of ingress points may contain duplicate Host or RouterName values. Routes are considered live once they are `Ready`
+                  items:
+                    description: RouteIngress holds information about the places where a route is exposed.
+                    properties:
+                      conditions:
+                        description: Conditions is the state of the route, may be empty.
+                        items:
+                          description: RouteIngressCondition contains details for the current condition of this route on a particular router.
+                          properties:
+                            lastTransitionTime:
+                              description: RFC 3339 date and time when this condition last transitioned
+                              format: date-time
+                              type: string
+                            message:
+                              description: Human readable message indicating details about last transition.
+                              type: string
+                            reason:
+                              description: (brief) reason for the condition's last transition, and is usually a machine and human readable constant
+                              type: string
+                            status:
+                              description: Status is the status of the condition. Can be True, False, Unknown.
+                              type: string
+                            type:
+                              description: Type is the type of the condition. Currently only Admitted.
+                              type: string
+                          required:
+                            - status
+                            - type
+                          type: object
+                        type: array
+                      host:
+                        description: Host is the host string under which the route is exposed; this value is required
+                        type: string
+                      routerCanonicalHostname:
+                        description: CanonicalHostname is the external host name for the router that can be used as a CNAME for the host requested for this route. This value is optional and may not be set in all cases.
+                        type: string
+                      routerName:
+                        description: Name is a name chosen by the router to identify itself; this value is required
+                        type: string
+                      wildcardPolicy:
+                        description: Wildcard policy is the wildcard policy that was allowed where this route is exposed.
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -106,6 +106,8 @@ var _ = Describe("Testing Route to HTTPProxy Controller", func() {
 				return
 			}
 			Expect(err).To(BeNil())
+
+			// wait 1s to make sure the route is deleted properly
 		})
 
 		It("should exit with no error when the pause label is set, no object should be created", func() {

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1,0 +1,597 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/snapp-incubator/route-to-contour-httpproxy/pkg/utils"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/snapp-incubator/route-to-contour-httpproxy/internal/config"
+	"github.com/snapp-incubator/route-to-contour-httpproxy/pkg/consts"
+	v12 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+const (
+	APIVersionRoute   = "route.openshift.io/v1"
+	APIVersionService = "v1"
+	KindRoute         = "Route"
+	KindService       = "Service"
+	DefaultNamespace  = "default"
+	RouterName        = "default"
+	RouteTimeout      = "120s"
+
+	ServiceFooName             = "foo"
+	RouteFooName               = "foo"
+	RouteFooFQDN               = "test.apps.example.com"
+	RouteFooWildCardPolicyType = "None"
+
+	RateLimitRequests = 100
+	RouteIPWhiteList  = "1.1.1.1 8.8.8.8"
+)
+
+var (
+	err             error
+	ServiceWeight   int32 = 100
+	ServiceFooPorts       = []v12.ServicePort{{Name: "https", Port: 443}}
+	RouterTypeMeta        = v1.TypeMeta{Kind: KindRoute, APIVersion: APIVersionRoute}
+	ServiceTypeMeta       = v1.TypeMeta{Kind: KindService, APIVersion: APIVersionService}
+)
+
+var _ = Describe("Testing Route to HTTPProxy Controller", func() {
+	cfg, errConfig := config.GetConfig("../../hack/config.yaml")
+	if errConfig != nil {
+		fmt.Println(err, "failed to get config")
+		os.Exit(1)
+	}
+
+	Context("Testing Reconcile loop functionality", func() {
+		BeforeEach(func() {
+			// Create Service
+			objService := v12.Service{
+				TypeMeta: ServiceTypeMeta,
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: DefaultNamespace,
+					Name:      ServiceFooName,
+				},
+				Spec: v12.ServiceSpec{
+					Ports: ServiceFooPorts,
+					Type:  v12.ServiceTypeClusterIP,
+					Selector: map[string]string{
+						"app": "test",
+					},
+				},
+			}
+			err = k8sClient.Create(context.Background(), &objService)
+			if err != nil && errors.IsAlreadyExists(err) {
+				fmt.Println(objService.ObjectMeta.Name, "Already exists")
+				return
+			}
+			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			// Delete Service
+			objService := v12.Service{
+				TypeMeta: ServiceTypeMeta,
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: DefaultNamespace,
+					Name:      ServiceFooName,
+				},
+				Spec: v12.ServiceSpec{
+					Ports: ServiceFooPorts,
+					Type:  v12.ServiceTypeClusterIP,
+					Selector: map[string]string{
+						"app": "test",
+					},
+				},
+			}
+			err = k8sClient.Delete(context.Background(), &objService)
+			if err != nil && errors.IsNotFound(err) {
+				fmt.Println(objService.ObjectMeta.Name, "Not found")
+				return
+			}
+			Expect(err).To(BeNil())
+		})
+
+		It("should exit with no error when the pause label is set, no object should be created", func() {
+			objRoute := routev1.Route{
+				TypeMeta: RouterTypeMeta,
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: DefaultNamespace,
+					Name:      RouteFooName,
+					Labels: map[string]string{
+						consts.RouteShardLabel: RouterName,
+					},
+					Annotations: map[string]string{
+						consts.AnnotTimeout:                      RouteTimeout,
+						consts.AnnotationKeyReconciliationPaused: "",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: RouteFooFQDN,
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.IntOrString{IntVal: 443},
+					},
+					To: routev1.RouteTargetReference{
+						Name:   ServiceFooName,
+						Kind:   KindService,
+						Weight: &ServiceWeight,
+					},
+					WildcardPolicy: routev1.WildcardPolicyType(RouteFooWildCardPolicyType),
+				},
+			}
+			err = k8sClient.Create(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			objRoute.Status = routev1.RouteStatus{
+				Ingress: []routev1.RouteIngress{
+					{
+						RouterName: RouterName,
+						Conditions: []routev1.RouteIngressCondition{
+							{
+								Status: v12.ConditionStatus(v1.ConditionTrue),
+								Type:   routev1.RouteAdmitted,
+							},
+						},
+					},
+				},
+			}
+			err = k8sClient.Status().Update(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			tt := routev1.Route{}
+			err = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: DefaultNamespace, Name: RouteFooName}, &tt)
+			Expect(err).To(BeNil())
+
+			httpProxyList := contourv1.HTTPProxyList{}
+			err = k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))
+			Expect(err).To(BeNil())
+			Expect(len(httpProxyList.Items)).To(Equal(0))
+
+			err = k8sClient.Delete(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+		})
+
+		It("should exit with no error if the route object is not admitted", func() {
+			objRoute := routev1.Route{
+				TypeMeta: RouterTypeMeta,
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: DefaultNamespace,
+					Name:      RouteFooName,
+					Labels: map[string]string{
+						consts.RouteShardLabel: RouterName,
+					},
+					Annotations: map[string]string{
+						consts.AnnotTimeout: RouteTimeout,
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: RouteFooFQDN,
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.IntOrString{IntVal: 443},
+					},
+					To: routev1.RouteTargetReference{
+						Name:   ServiceFooName,
+						Kind:   KindService,
+						Weight: &ServiceWeight,
+					},
+					WildcardPolicy: routev1.WildcardPolicyType(RouteFooWildCardPolicyType),
+				},
+			}
+			err = k8sClient.Create(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			tt := routev1.Route{}
+			err = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: DefaultNamespace, Name: RouteFooName}, &tt)
+			Expect(err).To(BeNil())
+
+			httpProxyList := contourv1.HTTPProxyList{}
+			err = k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))
+			Expect(err).To(BeNil())
+			Expect(len(httpProxyList.Items)).To(Equal(0))
+
+			err = k8sClient.Delete(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+		})
+
+		It("should create HTTPProxy object when everything is alright", func() {
+			objRoute := routev1.Route{
+				TypeMeta: RouterTypeMeta,
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: DefaultNamespace,
+					Name:      RouteFooName,
+					Labels: map[string]string{
+						consts.RouteShardLabel: RouterName,
+					},
+					Annotations: map[string]string{
+						consts.AnnotTimeout: RouteTimeout,
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: RouteFooFQDN,
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.IntOrString{IntVal: 443},
+					},
+					To: routev1.RouteTargetReference{
+						Name:   ServiceFooName,
+						Kind:   KindService,
+						Weight: &ServiceWeight,
+					},
+					WildcardPolicy: routev1.WildcardPolicyType(RouteFooWildCardPolicyType),
+				},
+			}
+			err = k8sClient.Create(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			objRoute.Status = routev1.RouteStatus{
+				Ingress: []routev1.RouteIngress{
+					{
+						RouterName: RouterName,
+						Conditions: []routev1.RouteIngressCondition{
+							{
+								Status: v12.ConditionStatus(v1.ConditionTrue),
+								Type:   routev1.RouteAdmitted,
+							},
+						},
+					},
+				},
+			}
+			err = k8sClient.Status().Update(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			rObj := routev1.Route{}
+			err = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: DefaultNamespace, Name: RouteFooName}, &rObj)
+			Expect(err).To(BeNil())
+
+			time.Sleep(1 * time.Second)
+			httpProxyList := contourv1.HTTPProxyList{}
+			err = k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))
+			Expect(err).To(BeNil())
+			Expect(len(httpProxyList.Items)).To(Equal(1))
+			Expect(httpProxyList.Items[0].Spec.VirtualHost.Fqdn).To(Equal(RouteFooFQDN))
+			Expect(httpProxyList.Items[0].Spec.Routes[0].TimeoutPolicy.Response).To(Equal(RouteTimeout))
+
+			err = k8sClient.Delete(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			httpProxyList = contourv1.HTTPProxyList{}
+			err = k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))
+			Expect(err).To(BeNil())
+			Expect(len(httpProxyList.Items)).To(Equal(1))
+		})
+
+		It("should create HTTPProxy object with custom load balancer algorithm (note: this case only tests the algorithm)", func() {
+			objRoute := routev1.Route{
+				TypeMeta: RouterTypeMeta,
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: DefaultNamespace,
+					Name:      RouteFooName,
+					Labels: map[string]string{
+						consts.RouteShardLabel: RouterName,
+					},
+					Annotations: map[string]string{
+						//consts.AnnotTimeout:        RouteTimeout,
+						consts.AnnotBalance:        "roundrobin",
+						consts.AnnotDisableCookies: "true",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: RouteFooFQDN,
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.IntOrString{IntVal: 443},
+					},
+					To: routev1.RouteTargetReference{
+						Name:   ServiceFooName,
+						Kind:   KindService,
+						Weight: &ServiceWeight,
+					},
+					WildcardPolicy: routev1.WildcardPolicyType(RouteFooWildCardPolicyType),
+				},
+			}
+			err = k8sClient.Create(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			objRoute.Status = routev1.RouteStatus{
+				Ingress: []routev1.RouteIngress{
+					{
+						RouterName: RouterName,
+						Conditions: []routev1.RouteIngressCondition{
+							{
+								Status: v12.ConditionStatus(v1.ConditionTrue),
+								Type:   routev1.RouteAdmitted,
+							},
+						},
+					},
+				},
+			}
+			err = k8sClient.Status().Update(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			rObj := routev1.Route{}
+			err = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: DefaultNamespace, Name: RouteFooName}, &rObj)
+			Expect(err).To(BeNil())
+
+			time.Sleep(1 * time.Second)
+			httpProxyList := contourv1.HTTPProxyList{}
+			err = k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))
+			Expect(err).To(BeNil())
+			Expect(len(httpProxyList.Items)).To(Equal(1))
+			Expect(httpProxyList.Items[0].Spec.Routes[0].LoadBalancerPolicy.Strategy).To(Equal(consts.StrategyRoundRobin))
+
+			err = k8sClient.Delete(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+		})
+
+		It("should create HTTPProxy object with rate limit enabled (note: this case only tests the rate limit)", func() {
+			objRoute := routev1.Route{
+				TypeMeta: RouterTypeMeta,
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: DefaultNamespace,
+					Name:      RouteFooName,
+					Labels: map[string]string{
+						consts.RouteShardLabel: RouterName,
+					},
+					Annotations: map[string]string{
+						consts.AnnotTimeout:           RouteTimeout,
+						consts.AnnotRateLimit:         "true",
+						consts.AnnotRateLimitHttpRate: strconv.Itoa(RateLimitRequests),
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: RouteFooFQDN,
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.IntOrString{IntVal: 443},
+					},
+					To: routev1.RouteTargetReference{
+						Name:   ServiceFooName,
+						Kind:   KindService,
+						Weight: &ServiceWeight,
+					},
+					WildcardPolicy: routev1.WildcardPolicyType(RouteFooWildCardPolicyType),
+				},
+			}
+			err = k8sClient.Create(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			objRoute.Status = routev1.RouteStatus{
+				Ingress: []routev1.RouteIngress{
+					{
+						RouterName: RouterName,
+						Conditions: []routev1.RouteIngressCondition{
+							{
+								Status: v12.ConditionStatus(v1.ConditionTrue),
+								Type:   routev1.RouteAdmitted,
+							},
+						},
+					},
+				},
+			}
+			err = k8sClient.Status().Update(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			rObj := routev1.Route{}
+			err = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: DefaultNamespace, Name: RouteFooName}, &rObj)
+			Expect(err).To(BeNil())
+
+			time.Sleep(1 * time.Second)
+			httpProxyList := contourv1.HTTPProxyList{}
+			err = k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))
+			Expect(err).To(BeNil())
+			Expect(len(httpProxyList.Items)).To(Equal(1))
+			Expect(httpProxyList.Items[0].Spec.Routes[0].RateLimitPolicy.Local.Requests).To(Equal(utils.CalculateRateLimit(cfg.RouterToContourRatio, RateLimitRequests)))
+
+			err = k8sClient.Delete(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+		})
+
+		It("should create HTTPProxy object with ip whitelist enabled (note: this case only tests the whitelist)", func() {
+			objRoute := routev1.Route{
+				TypeMeta: RouterTypeMeta,
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: DefaultNamespace,
+					Name:      RouteFooName,
+					Labels: map[string]string{
+						consts.RouteShardLabel: RouterName,
+					},
+					Annotations: map[string]string{
+						consts.AnnotTimeout:     RouteTimeout,
+						consts.AnnotIPWhitelist: RouteIPWhiteList,
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: RouteFooFQDN,
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.IntOrString{IntVal: 443},
+					},
+					To: routev1.RouteTargetReference{
+						Name:   ServiceFooName,
+						Kind:   KindService,
+						Weight: &ServiceWeight,
+					},
+					WildcardPolicy: routev1.WildcardPolicyType(RouteFooWildCardPolicyType),
+				},
+			}
+			err = k8sClient.Create(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			objRoute.Status = routev1.RouteStatus{
+				Ingress: []routev1.RouteIngress{
+					{
+						RouterName: RouterName,
+						Conditions: []routev1.RouteIngressCondition{
+							{
+								Status: v12.ConditionStatus(v1.ConditionTrue),
+								Type:   routev1.RouteAdmitted,
+							},
+						},
+					},
+				},
+			}
+			err = k8sClient.Status().Update(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			rObj := routev1.Route{}
+			err = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: DefaultNamespace, Name: RouteFooName}, &rObj)
+			Expect(err).To(BeNil())
+
+			time.Sleep(1 * time.Second)
+			httpProxyList := contourv1.HTTPProxyList{}
+			err = k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))
+			Expect(err).To(BeNil())
+			Expect(len(httpProxyList.Items)).To(Equal(1))
+			Expect(httpProxyList.Items[0].Spec.Routes[0].IPAllowFilterPolicy).NotTo(BeNil())
+			for _, ipWhiteList := range strings.Split(RouteIPWhiteList, " ") {
+				found := false
+				for _, ipFilterPolicy := range httpProxyList.Items[0].Spec.Routes[0].IPAllowFilterPolicy {
+					if ipFilterPolicy.CIDR == ipWhiteList {
+						found = true
+					}
+					if found {
+						break
+					}
+				}
+				Expect(found).To(BeTrue())
+			}
+
+			err = k8sClient.Delete(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+		})
+
+		It("should create HTTPProxy with TCPProxy when tls is pass through (note: this case only test services on TCPProxy", func() {
+			objRoute := routev1.Route{
+				TypeMeta: RouterTypeMeta,
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: DefaultNamespace,
+					Name:      RouteFooName,
+					Labels: map[string]string{
+						consts.RouteShardLabel: RouterName,
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: RouteFooFQDN,
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.IntOrString{IntVal: 443},
+					},
+					To: routev1.RouteTargetReference{
+						Name:   ServiceFooName,
+						Kind:   KindService,
+						Weight: &ServiceWeight,
+					},
+					WildcardPolicy: routev1.WildcardPolicyType(RouteFooWildCardPolicyType),
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationPassthrough,
+					},
+				},
+			}
+			err = k8sClient.Create(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			objRoute.Status = routev1.RouteStatus{
+				Ingress: []routev1.RouteIngress{
+					{
+						RouterName: RouterName,
+						Conditions: []routev1.RouteIngressCondition{
+							{
+								Status: v12.ConditionStatus(v1.ConditionTrue),
+								Type:   routev1.RouteAdmitted,
+							},
+						},
+					},
+				},
+			}
+			err = k8sClient.Status().Update(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			rObj := routev1.Route{}
+			err = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: DefaultNamespace, Name: RouteFooName}, &rObj)
+			Expect(err).To(BeNil())
+
+			time.Sleep(1 * time.Second)
+			httpProxyList := contourv1.HTTPProxyList{}
+			err = k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))
+			Expect(err).To(BeNil())
+			Expect(len(httpProxyList.Items)).To(Equal(1))
+			Expect(len(httpProxyList.Items[0].Spec.TCPProxy.Services)).To(Equal(1))
+			Expect(httpProxyList.Items[0].Spec.TCPProxy.Services[0].Name).To(Equal(ServiceFooName))
+
+			err = k8sClient.Delete(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+		})
+
+		It("should create HTTPProxy with TCPProxy when tls is edge (note: this case only tests tls related configs", func() {
+			objRoute := routev1.Route{
+				TypeMeta: RouterTypeMeta,
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: DefaultNamespace,
+					Name:      RouteFooName,
+					Labels: map[string]string{
+						consts.RouteShardLabel: RouterName,
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: RouteFooFQDN,
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.IntOrString{IntVal: 443},
+					},
+					To: routev1.RouteTargetReference{
+						Name:   ServiceFooName,
+						Kind:   KindService,
+						Weight: &ServiceWeight,
+					},
+					WildcardPolicy: routev1.WildcardPolicyType(RouteFooWildCardPolicyType),
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationEdge,
+					},
+				},
+			}
+			err = k8sClient.Create(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			objRoute.Status = routev1.RouteStatus{
+				Ingress: []routev1.RouteIngress{
+					{
+						RouterName: RouterName,
+						Conditions: []routev1.RouteIngressCondition{
+							{
+								Status: v12.ConditionStatus(v1.ConditionTrue),
+								Type:   routev1.RouteAdmitted,
+							},
+						},
+					},
+				},
+			}
+			err = k8sClient.Status().Update(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+
+			rObj := routev1.Route{}
+			err = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: DefaultNamespace, Name: RouteFooName}, &rObj)
+			Expect(err).To(BeNil())
+
+			time.Sleep(1 * time.Second)
+			httpProxyList := contourv1.HTTPProxyList{}
+			err = k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))
+			Expect(err).To(BeNil())
+			Expect(len(httpProxyList.Items)).To(Equal(1))
+			Expect(httpProxyList.Items[0].Spec.VirtualHost.TLS.SecretName).To(Equal(consts.GlobalTLSSecretName))
+
+			err = k8sClient.Delete(context.Background(), &objRoute)
+			Expect(err).To(BeNil())
+		})
+
+		It("To enable Debug mode", func() {
+			Expect("foo").To(Equal("foo"))
+		})
+	})
+})

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -107,8 +107,8 @@ var _ = Describe("Testing Route to HTTPProxy Controller", func() {
 			}
 			Expect(err).To(BeNil())
 
-			// wait 1s to make sure the route is deleted properly
-			time.Sleep(1 * time.Second)
+			// wait 3s to make sure the route is deleted properly
+			time.Sleep(3 * time.Second)
 
 		})
 
@@ -289,7 +289,6 @@ var _ = Describe("Testing Route to HTTPProxy Controller", func() {
 						consts.RouteShardLabel: RouterName,
 					},
 					Annotations: map[string]string{
-						//consts.AnnotTimeout:        RouteTimeout,
 						consts.AnnotBalance:        "roundrobin",
 						consts.AnnotDisableCookies: "true",
 					},

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Testing Route to HTTPProxy Controller", func() {
 		os.Exit(1)
 	}
 
-	Context("Testing Reconcile loop functionality", func() {
+	Context("Testing Reconcile loop functionality", Serial, func() {
 		BeforeEach(func() {
 			// Create Service
 			objService := v12.Service{

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1,26 +1,29 @@
 package controller
 
 import (
-	"context"
-	"fmt"
+	"github.com/snapp-incubator/route-to-contour-httpproxy/internal/config"
+	"github.com/snapp-incubator/route-to-contour-httpproxy/pkg/consts"
+	"github.com/snapp-incubator/route-to-contour-httpproxy/pkg/utils"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/snapp-incubator/route-to-contour-httpproxy/pkg/utils"
+	v12 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"context"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
-	"github.com/snapp-incubator/route-to-contour-httpproxy/internal/config"
-	"github.com/snapp-incubator/route-to-contour-httpproxy/pkg/consts"
-	v12 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
+
+	"fmt"
 )
 
 const (

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -108,6 +108,8 @@ var _ = Describe("Testing Route to HTTPProxy Controller", func() {
 			Expect(err).To(BeNil())
 
 			// wait 1s to make sure the route is deleted properly
+			time.Sleep(1 * time.Second)
+
 		})
 
 		It("should exit with no error when the pause label is set, no object should be created", func() {

--- a/internal/controller/route/handler.go
+++ b/internal/controller/route/handler.go
@@ -555,10 +555,6 @@ func (r *Reconciler) assembleTLSSecret(route *routev1.Route) *corev1.Secret {
 func (r *Reconciler) getSameHostRoutes(ctx context.Context, namespace, host string) ([]routev1.Route, error) {
 	sameHostRouteList := &routev1.RouteList{}
 
-	if err := r.List(ctx, sameHostRouteList, client.InNamespace(namespace)); err != nil {
-		return nil, err
-	}
-
 	if err := r.List(ctx, sameHostRouteList, client.InNamespace(namespace), client.MatchingFields{
 		"spec.host": host,
 	}); err != nil {

--- a/internal/controller/route/handler.go
+++ b/internal/controller/route/handler.go
@@ -554,7 +554,6 @@ func (r *Reconciler) assembleTLSSecret(route *routev1.Route) *corev1.Secret {
 // the routes are sorted in ascending order by .metadata.creationTimestamp field
 func (r *Reconciler) getSameHostRoutes(ctx context.Context, namespace, host string) ([]routev1.Route, error) {
 	sameHostRouteList := &routev1.RouteList{}
-
 	if err := r.List(ctx, sameHostRouteList, client.InNamespace(namespace), client.MatchingFields{
 		"spec.host": host,
 	}); err != nil {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -18,18 +18,22 @@ package controller
 
 import (
 	"context"
-	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/snapp-incubator/route-to-contour-httpproxy/internal/config"
-	"github.com/snapp-incubator/route-to-contour-httpproxy/internal/controller/route"
 	"k8s.io/client-go/kubernetes"
-	"os"
-	"path/filepath"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"testing"
+
+	"github.com/snapp-incubator/route-to-contour-httpproxy/internal/controller/route"
+
+	"github.com/snapp-incubator/route-to-contour-httpproxy/internal/config"
+
+	"fmt"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -17,11 +17,19 @@ limitations under the License.
 package controller
 
 import (
-	"path/filepath"
-	"testing"
-
+	"context"
+	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/snapp-incubator/route-to-contour-httpproxy/internal/config"
+	"github.com/snapp-incubator/route-to-contour-httpproxy/internal/controller/route"
+	"k8s.io/client-go/kubernetes"
+	"os"
+	"path/filepath"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"testing"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -50,8 +58,10 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "external-crd"),
+		},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	var err error
@@ -60,16 +70,59 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
+	err = routev1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = contourv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
+	K8sClientSet, err := kubernetes.NewForConfig(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(K8sClientSet).NotTo(BeNil())
+
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+	})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sManager).NotTo(BeNil())
+
+	if err := k8sManager.GetFieldIndexer().IndexField(
+		context.Background(),
+		&routev1.Route{},
+		"spec.host",
+		func(object client.Object) []string {
+			r := object.(*routev1.Route)
+			return []string{r.Spec.Host}
+		}); err != nil {
+		fmt.Println(err, "failed to create index for .spec.host", "controller", "Route")
+		os.Exit(1)
+	}
+
+	cfg, err := config.GetConfig("../../hack/config.yaml")
+	if err != nil {
+		fmt.Println(err, "failed to get config")
+		os.Exit(1)
+	}
+
+	routeReconcileObj := route.NewReconciler(k8sManager, cfg)
+	err = (routeReconcileObj).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
 })
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	_ = testEnv.Stop()
+	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -16,6 +16,9 @@ const (
 	AnnotIPWhitelist       = haproxyAnnotationPrefix + "ip_whitelist"
 	AnnotDisableCookies    = haproxyAnnotationPrefix + "disable_cookies"
 
+	AnnotationKeyPrefix               = "snappcloud.io/"
+	AnnotationKeyReconciliationPaused = AnnotationKeyPrefix + "paused"
+
 	TLSSecretNS         = "openshift-ingress"
 	TLSSecretName       = "letsencrypt"
 	GlobalTLSSecretName = TLSSecretNS + "/" + TLSSecretName

--- a/pkg/utils/meta.go
+++ b/pkg/utils/meta.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"github.com/snapp-incubator/route-to-contour-httpproxy/pkg/consts"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,6 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	"fmt"
 )
 
 const (

--- a/pkg/utils/meta.go
+++ b/pkg/utils/meta.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"github.com/snapp-incubator/route-to-contour-httpproxy/pkg/consts"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -11,9 +12,6 @@ import (
 )
 
 const (
-	AnnotationKeyPrefix               = "snappcloud.io/"
-	AnnotationKeyReconciliationPaused = AnnotationKeyPrefix + "paused"
-
 	RouteFinalizer = "snappcloud.io/wait-for-httpproxy-cleanup"
 )
 
@@ -27,7 +25,7 @@ func IsPaused(obj metav1.Object) bool {
 	if annotations == nil {
 		return false
 	}
-	_, ok := annotations[AnnotationKeyReconciliationPaused]
+	_, ok := annotations[consts.AnnotationKeyReconciliationPaused]
 	return ok
 }
 

--- a/pkg/utils/route.go
+++ b/pkg/utils/route.go
@@ -132,3 +132,7 @@ func GetTimeout(route *routev1.Route, defaultTimeout config.DefaultTimeout) stri
 		return defaultTimeout.DefaultClass
 	}
 }
+
+func CalculateRateLimit(ratio, rateLimit int) uint32 {
+	return uint32(rateLimit * ratio * 6)
+}


### PR DESCRIPTION
Here are the test cases added for the controller:
- no object should be created when the pause annotation is set on the route object
- no object should be created when the route is not in the Admitted state
- the creation of HTTPProxy without TLS set on the route, and everything is alright
- the creation of HTTPProxy without TLS set on the route, and the route has a custom load balancer algorithm
- the creation of HTTPProxy without TLS set on the route, and the route has Ratelimit enabled
- the creation of HTTPProxy without TLS set on the route, and the route has the IP whitelist enabled
- the creation of TCPProxy with passthrough TLS enabled on the route
- the creation of HTTPProxy with edge TLS enabled on the route

Also, I had to change some parts of the code to make it easier to test.