### PR TITLE
Use deterministic names for httpproxies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,31 @@
+name: Release Helm Chart
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          charts_dir: deploy/charts

--- a/Makefile
+++ b/Makefile
@@ -164,3 +164,14 @@ tidy:
 .PHONY: vendor
 vendor: tidy
 	go mod vendor
+
+######################### Helmify
+HELMIFY ?= $(LOCALBIN)/helmify
+
+.PHONY: helmify
+helmify: $(HELMIFY) ## Download helmify locally if necessary.
+$(HELMIFY): $(LOCALBIN)
+	test -s $(LOCALBIN)/helmify || GOBIN=$(LOCALBIN) go install github.com/arttor/helmify/cmd/helmify@v0.4.5
+
+helm: manifests kustomize helmify
+	$(KUSTOMIZE) build config/default | $(HELMIFY) deploy/charts/route-to-contour-httpproxy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# Work In Progress...
-
 # route-to-contour-httpproxy
 
 A Kubernetes controller for converting Openshift HAProxy Route to Contour HTTPProxy
@@ -7,71 +5,5 @@ A Kubernetes controller for converting Openshift HAProxy Route to Contour HTTPPr
 ## Description
 
 Currently, the project consists of a single controller which watches `route` and `httpproxy` resources.
-The controller tries to create/update an `httpproxy` that matches the corresponding `route` in functionalities, e.g. tls
+The controller tries to create/update an `httpproxy` that matches the corresponding `route(s)` in functionalities, e.g. tls
 termination, port mapping, etc.
-
-## Getting Started
-
-You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for
-testing, or run against a remote cluster.
-**Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever
-cluster `kubectl cluster-info` shows).
-
-### Running on the cluster
-
-1. Build and push your image to the location specified by `IMG`:
-
-    ```sh
-    make docker-build docker-push IMG=<some-registry>/route-to-contour-httpproxy:tag
-    ```
-
-2. Deploy the controller to the cluster with the image specified by `IMG`:
-
-    ```sh
-    make deploy IMG=<some-registry>/route-to-contour-httpproxy:tag
-    ```
-
-### Undeploy controller
-
-UnDeploy the controller from the cluster:
-
-```sh
-make undeploy
-```
-
-## Contributing
-
-### How it works
-
-This project aims to follow the
-Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
-
-It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/),
-which provide a reconcile function responsible for synchronizing resources until the desired state is reached on the
-cluster.
-
-### Running Tests
-
-1. Make sure the sample config exists first.
-
-```shell
-ls -l hack/config.yaml
-```
-
-2. Run the tests defined inside Makefile. These tests run on envtest, so you don't need to connect to a working cluster.
-
-```shell
-make test
-```
-
-### Test It Out
-
-1. Run the controller (this will run in the foreground, so switch to a new terminal if you want to leave it running):
-
-```sh
-make run
-```
-
-**NOTE:** Run `make --help` for more information on all potential `make` targets
-
-More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)

--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
 data:
   config.yaml: |
     routeToContourRatio: 1
+    commonHostSuffix: .okd4.ts-1.staging-snappcloud.io
     defaultTimeout:
       publicClass: 5s
       interDcClass: 5s

--- a/deploy/charts/route-to-contour-httpproxy/.helmignore
+++ b/deploy/charts/route-to-contour-httpproxy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/charts/route-to-contour-httpproxy/Chart.yaml
+++ b/deploy/charts/route-to-contour-httpproxy/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: route-to-contour-httpproxy
+description: A Helm chart for Kubernetes
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/deploy/charts/route-to-contour-httpproxy/templates/_helpers.tpl
+++ b/deploy/charts/route-to-contour-httpproxy/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "route-to-contour-httpproxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "route-to-contour-httpproxy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "route-to-contour-httpproxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "route-to-contour-httpproxy.labels" -}}
+helm.sh/chart: {{ include "route-to-contour-httpproxy.chart" . }}
+{{ include "route-to-contour-httpproxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "route-to-contour-httpproxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "route-to-contour-httpproxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "route-to-contour-httpproxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "route-to-contour-httpproxy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/route-to-contour-httpproxy/templates/controller-manager-config.yaml
+++ b/deploy/charts/route-to-contour-httpproxy/templates/controller-manager-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "route-to-contour-httpproxy.fullname" . }}-controller-manager-config
+  labels:
+  {{- include "route-to-contour-httpproxy.labels" . | nindent 4 }}
+data:
+  config.yaml: {{ .Values.controllerManagerConfig.configYaml | toYaml | indent 1
+    }}

--- a/deploy/charts/route-to-contour-httpproxy/templates/deployment.yaml
+++ b/deploy/charts/route-to-contour-httpproxy/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "route-to-contour-httpproxy.fullname" . }}-controller-manager
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: route-to-contour-httpproxy
+    app.kubernetes.io/part-of: route-to-contour-httpproxy
+    control-plane: controller-manager
+  {{- include "route-to-contour-httpproxy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.controllerManager.replicas }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+    {{- include "route-to-contour-httpproxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+      {{- include "route-to-contour-httpproxy.selectorLabels" . | nindent 8 }}
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      containers:
+      - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
+        command:
+        - /manager
+        env:
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ quote .Values.kubernetesClusterDomain }}
+        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
+          | default .Chart.AppVersion }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{- toYaml .Values.controllerManager.manager.resources | nindent 10
+          }}
+        volumeMounts:
+        - mountPath: /route-to-contour-httpproxy/config/
+          name: config-volume
+      serviceAccountName: {{ include "route-to-contour-httpproxy.fullname" . }}-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: {{ include "route-to-contour-httpproxy.fullname" . }}-controller-manager-config
+        name: config-volume

--- a/deploy/charts/route-to-contour-httpproxy/templates/leader-election-rbac.yaml
+++ b/deploy/charts/route-to-contour-httpproxy/templates/leader-election-rbac.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "route-to-contour-httpproxy.fullname" . }}-leader-election-role
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: route-to-contour-httpproxy
+    app.kubernetes.io/part-of: route-to-contour-httpproxy
+  {{- include "route-to-contour-httpproxy.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "route-to-contour-httpproxy.fullname" . }}-leader-election-rolebinding
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: route-to-contour-httpproxy
+    app.kubernetes.io/part-of: route-to-contour-httpproxy
+  {{- include "route-to-contour-httpproxy.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "route-to-contour-httpproxy.fullname" . }}-leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "route-to-contour-httpproxy.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/deploy/charts/route-to-contour-httpproxy/templates/manager-rbac.yaml
+++ b/deploy/charts/route-to-contour-httpproxy/templates/manager-rbac.yaml
@@ -1,0 +1,83 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "route-to-contour-httpproxy.fullname" . }}-manager-role
+  labels:
+  {{- include "route-to-contour-httpproxy.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - httpproxies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "route-to-contour-httpproxy.fullname" . }}-manager-rolebinding
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: route-to-contour-httpproxy
+    app.kubernetes.io/part-of: route-to-contour-httpproxy
+  {{- include "route-to-contour-httpproxy.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "route-to-contour-httpproxy.fullname" . }}-manager-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "route-to-contour-httpproxy.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/deploy/charts/route-to-contour-httpproxy/templates/metrics-reader-rbac.yaml
+++ b/deploy/charts/route-to-contour-httpproxy/templates/metrics-reader-rbac.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "route-to-contour-httpproxy.fullname" . }}-metrics-reader
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: route-to-contour-httpproxy
+    app.kubernetes.io/part-of: route-to-contour-httpproxy
+  {{- include "route-to-contour-httpproxy.labels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/deploy/charts/route-to-contour-httpproxy/templates/metrics-service.yaml
+++ b/deploy/charts/route-to-contour-httpproxy/templates/metrics-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "route-to-contour-httpproxy.fullname" . }}-controller-manager-metrics-service
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: route-to-contour-httpproxy
+    app.kubernetes.io/part-of: route-to-contour-httpproxy
+    control-plane: controller-manager
+  {{- include "route-to-contour-httpproxy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.metricsService.type }}
+  selector:
+    control-plane: controller-manager
+  {{- include "route-to-contour-httpproxy.selectorLabels" . | nindent 4 }}
+  ports:
+	{{- .Values.metricsService.ports | toYaml | nindent 2 -}}

--- a/deploy/charts/route-to-contour-httpproxy/templates/proxy-rbac.yaml
+++ b/deploy/charts/route-to-contour-httpproxy/templates/proxy-rbac.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "route-to-contour-httpproxy.fullname" . }}-proxy-role
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: route-to-contour-httpproxy
+    app.kubernetes.io/part-of: route-to-contour-httpproxy
+  {{- include "route-to-contour-httpproxy.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "route-to-contour-httpproxy.fullname" . }}-proxy-rolebinding
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: route-to-contour-httpproxy
+    app.kubernetes.io/part-of: route-to-contour-httpproxy
+  {{- include "route-to-contour-httpproxy.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "route-to-contour-httpproxy.fullname" . }}-proxy-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "route-to-contour-httpproxy.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/deploy/charts/route-to-contour-httpproxy/templates/serviceaccount.yaml
+++ b/deploy/charts/route-to-contour-httpproxy/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "route-to-contour-httpproxy.fullname" . }}-controller-manager
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: route-to-contour-httpproxy
+    app.kubernetes.io/part-of: route-to-contour-httpproxy
+  {{- include "route-to-contour-httpproxy.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}

--- a/deploy/charts/route-to-contour-httpproxy/values.yaml
+++ b/deploy/charts/route-to-contour-httpproxy/values.yaml
@@ -1,0 +1,34 @@
+controllerManager:
+  manager:
+    args:
+    - --leader-elect
+    - --config=/route-to-contour-httpproxy/config/config.yaml
+    image:
+      repository: ghcr.io/snapp-incubator/route-to-contour-httpproxy
+      tag: latest
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+  replicas: 1
+  serviceAccount:
+    annotations: {}
+controllerManagerConfig:
+  configYaml: |-
+    routeToContourRatio: 1
+    commonHostSuffix: .okd4.ts-1.staging-snappcloud.io
+    defaultTimeout:
+      publicClass: 5s
+      interDcClass: 5s
+      defaultClass: 30s
+kubernetesClusterDomain: cluster.local
+metricsService:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  type: ClusterIP

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -1,5 +1,5 @@
 routeToContourRatio: 1
-commonHostSuffix: okd4.ts-1.staging-snappcloud.io
+commonHostSuffix: .okd4.ts-1.staging-snappcloud.io
 defaultTimeout:
   publicClass: 5s
   interDcClass: 5s

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -1,4 +1,5 @@
 routeToContourRatio: 1
+commonHostSuffix: okd4.ts-1.staging-snappcloud.io
 defaultTimeout:
   publicClass: 5s
   interDcClass: 5s

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,7 @@ type Config struct {
 var (
 	defaultConfig = Config{
 		RouterToContourRatio: 1,
-		CommonHostSuffix:     "okd4.ts-1.staging-snappcloud.io",
+		CommonHostSuffix:     ".okd4.ts-1.staging-snappcloud.io",
 		DefaultTimeout: DefaultTimeout{
 			PublicClass:  "5s",
 			InterDcClass: "5s",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,12 +17,17 @@ type Config struct {
 	// The ratio of the count of router nodes to the count of contour nodes
 	RouterToContourRatio int `koanf:"routeToContourRatio"`
 
+	// When using the host of a route as the name of the httproxy,
+	// CommonHostSuffix will be removed from its end if present
+	CommonHostSuffix string `koanf:"commonHostSuffix"`
+
 	DefaultTimeout DefaultTimeout `koanf:"defaultTimeout"`
 }
 
 var (
 	defaultConfig = Config{
 		RouterToContourRatio: 1,
+		CommonHostSuffix:     "okd4.ts-1.staging-snappcloud.io",
 		DefaultTimeout: DefaultTimeout{
 			PublicClass:  "5s",
 			InterDcClass: "5s",

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -38,7 +38,6 @@ const (
 	StrategyRequestHash          = "RequestHash"
 	StrategyDefault              = StrategyWeightedLeastRequest
 
-	HTTPProxyGenerateName = "managed-httpproxy-"
 	TLSSecretGenerateName = "managed-tls-secret-"
 
 	NotFoundError = CustomError("not found")


### PR DESCRIPTION
Currently, we use `GenerateName` for httpproxy objects. When the controller-runtime cache is stale, we may create the same httpproxy objects more than once.
We [wait for a brief interval](https://github.com/projectcontour/contour/issues/3484) after creating each httpproxy object but recently we observed that even this wait is inadequate to prevent the issue.

This PR changes the code [to use deterministic names](https://github.com/kubernetes-sigs/controller-runtime/blob/main/FAQ.md#q-my-cache-might-be-stale-if-i-read-from-a-cache-how-should-i-deal-with-that) for creating httpproxy objects. This way Kubernetes (actually etcd) prevents us from creating the same object multiple times.
