### PR TITLE
enable both h2 & http/1.1 for inter-dc routes

### DIFF
--- a/config/external-crd/projectcontour.io_httpproxies.yaml
+++ b/config/external-crd/projectcontour.io_httpproxies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: contourconfigurations.projectcontour.io
 spec:
   preserveUnknownFields: false
@@ -224,6 +224,32 @@ spec:
                           \n Other values will produce an error. Contour's default
                           is overwrite."
                           type: string
+                        socketOptions:
+                          description: SocketOptions defines configurable socket options
+                            for the listeners. Single set of options are applied to
+                            all listeners.
+                          properties:
+                            tos:
+                              description: Defines the value for IPv4 TOS field (including
+                                6 bit DSCP field) for IP packets originating from Envoy
+                                listeners. Single value is applied to all listeners.
+                                If listeners are bound to IPv6-only addresses, setting
+                                this option will cause an error.
+                              format: int32
+                              maximum: 255
+                              minimum: 0
+                              type: integer
+                            trafficClass:
+                              description: Defines the value for IPv6 Traffic Class
+                                field (including 6 bit DSCP field) for IP packets originating
+                                from the Envoy listeners. Single value is applied to
+                                all listeners. If listeners are bound to IPv4-only addresses,
+                                setting this option will cause an error.
+                              format: int32
+                              maximum: 255
+                              minimum: 0
+                              type: integer
+                          type: object
                         tls:
                           description: TLS holds various configurable Envoy TLS listener
                             values.
@@ -255,6 +281,11 @@ spec:
                               items:
                                 type: string
                               type: array
+                            maximumProtocolVersion:
+                              description: "MaximumProtocolVersion is the maximum TLS
+                              version this vhost should negotiate. \n Values: `1.2`,
+                              `1.3`(default). \n Other values will produce an error."
+                              type: string
                             minimumProtocolVersion:
                               description: "MinimumProtocolVersion is the minimum TLS
                               version this vhost should negotiate. \n Values: `1.2`
@@ -724,9 +755,13 @@ spec:
                                           items:
                                             description: HeaderMatchCondition specifies
                                               how to conditionally match against HTTP
-                                              headers. The Name field is required, but
-                                              only one of the remaining fields should
-                                              be be provided.
+                                              headers. The Name field is required, only
+                                              one of Present, NotPresent, Contains,
+                                              NotContains, Exact, NotExact and Regex
+                                              can be set. For negative matching rules
+                                              only (e.g. NotContains or NotExact) you
+                                              can set TreatMissingAsEmpty. IgnoreCase
+                                              has no effect for Regex.
                                             properties:
                                               contains:
                                                 description: Contains specifies a substring
@@ -738,6 +773,12 @@ spec:
                                                   that the header value must be equal
                                                   to.
                                                 type: string
+                                              ignoreCase:
+                                                description: IgnoreCase specifies that
+                                                  string matching should be case insensitive.
+                                                  Note that this has no effect on the
+                                                  Regex parameter.
+                                                type: boolean
                                               name:
                                                 description: Name is the name of the
                                                   header to match against. Name is required.
@@ -775,6 +816,16 @@ spec:
                                                   expression pattern that must match
                                                   the header value.
                                                 type: string
+                                              treatMissingAsEmpty:
+                                                description: TreatMissingAsEmpty specifies
+                                                  if the header match rule specified
+                                                  header does not exist, this header
+                                                  value will be treated as empty. Defaults
+                                                  to false. Unlike the underlying Envoy
+                                                  implementation this is **only** supported
+                                                  for negative matches (e.g. NotContains,
+                                                  NotExact).
+                                                type: boolean
                                             required:
                                               - name
                                             type: object
@@ -1158,7 +1209,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: contourdeployments.projectcontour.io
 spec:
   preserveUnknownFields: false
@@ -1407,6 +1458,14 @@ spec:
                     or Deployment), node placement constraints for the pods, and various
                     options for the Envoy service.
                   properties:
+                    baseID:
+                      description: The base ID to use when allocating shared memory
+                        regions. if Envoy needs to be run multiple times on the same
+                        machine, each running Envoy will need a unique base ID so that
+                        the shared memory regions do not conflict. defaults to 0.
+                      format: int32
+                      minimum: 0
+                      type: integer
                     daemonSet:
                       description: DaemonSet describes the settings for running envoy
                         as a `DaemonSet`. if `WorkloadType` is `Deployment`,it's must
@@ -3322,6 +3381,15 @@ spec:
                             type: object
                           type: array
                       type: object
+                    overloadMaxHeapSize:
+                      description: 'OverloadMaxHeapSize defines the maximum heap memory
+                      of the envoy controlled by the overload manager. When the value
+                      is greater than 0, the overload manager is enabled, and when
+                      envoy reaches 95% of the maximum heap size, it performs a shrink
+                      heap operation, When it reaches 98% of the maximum heap size,
+                      Envoy Will stop accepting requests. More info: https://projectcontour.io/docs/main/config/overload-manager/'
+                      format: int64
+                      type: integer
                     podAnnotations:
                       additionalProperties:
                         type: string
@@ -3596,6 +3664,33 @@ spec:
                               `pass_through` \n Other values will produce an error.
                               Contour's default is overwrite."
                               type: string
+                            socketOptions:
+                              description: SocketOptions defines configurable socket
+                                options for the listeners. Single set of options are
+                                applied to all listeners.
+                              properties:
+                                tos:
+                                  description: Defines the value for IPv4 TOS field
+                                    (including 6 bit DSCP field) for IP packets originating
+                                    from Envoy listeners. Single value is applied to
+                                    all listeners. If listeners are bound to IPv6-only
+                                    addresses, setting this option will cause an error.
+                                  format: int32
+                                  maximum: 255
+                                  minimum: 0
+                                  type: integer
+                                trafficClass:
+                                  description: Defines the value for IPv6 Traffic Class
+                                    field (including 6 bit DSCP field) for IP packets
+                                    originating from the Envoy listeners. Single value
+                                    is applied to all listeners. If listeners are bound
+                                    to IPv4-only addresses, setting this option will
+                                    cause an error.
+                                  format: int32
+                                  maximum: 255
+                                  minimum: 0
+                                  type: integer
+                              type: object
                             tls:
                               description: TLS holds various configurable Envoy TLS
                                 listener values.
@@ -3629,6 +3724,12 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                maximumProtocolVersion:
+                                  description: "MaximumProtocolVersion is the maximum
+                                  TLS version this vhost should negotiate. \n Values:
+                                  `1.2`, `1.3`(default). \n Other values will produce
+                                  an error."
+                                  type: string
                                 minimumProtocolVersion:
                                   description: "MinimumProtocolVersion is the minimum
                                   TLS version this vhost should negotiate. \n Values:
@@ -4111,8 +4212,12 @@ spec:
                                                 description: HeaderMatchCondition specifies
                                                   how to conditionally match against
                                                   HTTP headers. The Name field is required,
-                                                  but only one of the remaining fields
-                                                  should be be provided.
+                                                  only one of Present, NotPresent, Contains,
+                                                  NotContains, Exact, NotExact and Regex
+                                                  can be set. For negative matching
+                                                  rules only (e.g. NotContains or NotExact)
+                                                  you can set TreatMissingAsEmpty. IgnoreCase
+                                                  has no effect for Regex.
                                                 properties:
                                                   contains:
                                                     description: Contains specifies
@@ -4124,6 +4229,12 @@ spec:
                                                       that the header value must be
                                                       equal to.
                                                     type: string
+                                                  ignoreCase:
+                                                    description: IgnoreCase specifies
+                                                      that string matching should be
+                                                      case insensitive. Note that this
+                                                      has no effect on the Regex parameter.
+                                                    type: boolean
                                                   name:
                                                     description: Name is the name of
                                                       the header to match against. Name
@@ -4164,6 +4275,17 @@ spec:
                                                       expression pattern that must match
                                                       the header value.
                                                     type: string
+                                                  treatMissingAsEmpty:
+                                                    description: TreatMissingAsEmpty
+                                                      specifies if the header match
+                                                      rule specified header does not
+                                                      exist, this header value will
+                                                      be treated as empty. Defaults
+                                                      to false. Unlike the underlying
+                                                      Envoy implementation this is **only**
+                                                      supported for negative matches
+                                                      (e.g. NotContains, NotExact).
+                                                    type: boolean
                                                 required:
                                                   - name
                                                 type: object
@@ -4413,7 +4535,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: extensionservices.projectcontour.io
 spec:
   preserveUnknownFields: false
@@ -4837,7 +4959,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: httpproxies.projectcontour.io
 spec:
   preserveUnknownFields: false
@@ -4889,6 +5011,17 @@ spec:
             spec:
               description: HTTPProxySpec defines the spec of the CRD.
               properties:
+                httpVersions:
+                  description: HttpVersions specify the http versions to offer for this
+                    HTTPProxy. If empty, the DefaultHTTPVersions from v1alpha1.EnvoyConfig
+                    will be used. It is ignored when TCPProxy is set.
+                  items:
+                    description: HttpVersion is an alias to enforce validation
+                    enum:
+                      - h2
+                      - http/1.1
+                    type: string
+                  type: array
                 includes:
                   description: Includes allow for specific routing configuration to
                     be included from another HTTPProxy, possibly in another namespace.
@@ -4926,6 +5059,11 @@ spec:
                                   description: Exact specifies a string that the header
                                     value must be equal to.
                                   type: string
+                                ignoreCase:
+                                  description: IgnoreCase specifies that string matching
+                                    should be case insensitive. Note that this has no
+                                    effect on the Regex parameter.
+                                  type: boolean
                                 name:
                                   description: Name is the name of the header to match
                                     against. Name is required. Header names are case
@@ -4957,6 +5095,14 @@ spec:
                                   description: Regex specifies a regular expression
                                     pattern that must match the header value.
                                   type: string
+                                treatMissingAsEmpty:
+                                  description: TreatMissingAsEmpty specifies if the
+                                    header match rule specified header does not exist,
+                                    this header value will be treated as empty. Defaults
+                                    to false. Unlike the underlying Envoy implementation
+                                    this is **only** supported for negative matches
+                                    (e.g. NotContains, NotExact).
+                                  type: boolean
                               required:
                                 - name
                               type: object
@@ -5083,6 +5229,11 @@ spec:
                                   description: Exact specifies a string that the header
                                     value must be equal to.
                                   type: string
+                                ignoreCase:
+                                  description: IgnoreCase specifies that string matching
+                                    should be case insensitive. Note that this has no
+                                    effect on the Regex parameter.
+                                  type: boolean
                                 name:
                                   description: Name is the name of the header to match
                                     against. Name is required. Header names are case
@@ -5114,6 +5265,14 @@ spec:
                                   description: Regex specifies a regular expression
                                     pattern that must match the header value.
                                   type: string
+                                treatMissingAsEmpty:
+                                  description: TreatMissingAsEmpty specifies if the
+                                    header match rule specified header does not exist,
+                                    this header value will be treated as empty. Defaults
+                                    to false. Unlike the underlying Envoy implementation
+                                    this is **only** supported for negative matches
+                                    (e.g. NotContains, NotExact).
+                                  type: boolean
                               required:
                                 - name
                               type: object
@@ -5641,8 +5800,13 @@ spec:
                                                   description: HeaderMatchCondition
                                                     specifies how to conditionally match
                                                     against HTTP headers. The Name field
-                                                    is required, but only one of the
-                                                    remaining fields should be be provided.
+                                                    is required, only one of Present,
+                                                    NotPresent, Contains, NotContains,
+                                                    Exact, NotExact and Regex can be
+                                                    set. For negative matching rules
+                                                    only (e.g. NotContains or NotExact)
+                                                    you can set TreatMissingAsEmpty.
+                                                    IgnoreCase has no effect for Regex.
                                                   properties:
                                                     contains:
                                                       description: Contains specifies
@@ -5654,6 +5818,13 @@ spec:
                                                         string that the header value
                                                         must be equal to.
                                                       type: string
+                                                    ignoreCase:
+                                                      description: IgnoreCase specifies
+                                                        that string matching should
+                                                        be case insensitive. Note that
+                                                        this has no effect on the Regex
+                                                        parameter.
+                                                      type: boolean
                                                     name:
                                                       description: Name is the name
                                                         of the header to match against.
@@ -5696,6 +5867,17 @@ spec:
                                                         regular expression pattern that
                                                         must match the header value.
                                                       type: string
+                                                    treatMissingAsEmpty:
+                                                      description: TreatMissingAsEmpty
+                                                        specifies if the header match
+                                                        rule specified header does not
+                                                        exist, this header value will
+                                                        be treated as empty. Defaults
+                                                        to false. Unlike the underlying
+                                                        Envoy implementation this is
+                                                        **only** supported for negative
+                                                        matches (e.g. NotContains, NotExact).
+                                                      type: boolean
                                                   required:
                                                     - name
                                                   type: object
@@ -5782,8 +5964,15 @@ spec:
                             type: object
                         type: object
                       requestHeadersPolicy:
-                        description: The policy for managing request headers during
-                          proxying.
+                        description: "The policy for managing request headers during
+                        proxying. \n You may dynamically rewrite the Host header to
+                        be forwarded upstream to the content of a request header using
+                        the below format \"%REQ(X-Header-Name)%\". If the value of
+                        the header is empty, it is ignored. \n *NOTE: Pay attention
+                        to the potential security implications of using this option.
+                        Provided header must come from trusted source. \n **NOTE:
+                        The header rewrite is only done while forwarding and has no
+                        bearing on the routing decision."
                         properties:
                           remove:
                             description: Remove specifies a list of HTTP header names
@@ -7001,8 +7190,12 @@ spec:
                                                 description: HeaderMatchCondition specifies
                                                   how to conditionally match against
                                                   HTTP headers. The Name field is required,
-                                                  but only one of the remaining fields
-                                                  should be be provided.
+                                                  only one of Present, NotPresent, Contains,
+                                                  NotContains, Exact, NotExact and Regex
+                                                  can be set. For negative matching
+                                                  rules only (e.g. NotContains or NotExact)
+                                                  you can set TreatMissingAsEmpty. IgnoreCase
+                                                  has no effect for Regex.
                                                 properties:
                                                   contains:
                                                     description: Contains specifies
@@ -7014,6 +7207,12 @@ spec:
                                                       that the header value must be
                                                       equal to.
                                                     type: string
+                                                  ignoreCase:
+                                                    description: IgnoreCase specifies
+                                                      that string matching should be
+                                                      case insensitive. Note that this
+                                                      has no effect on the Regex parameter.
+                                                    type: boolean
                                                   name:
                                                     description: Name is the name of
                                                       the header to match against. Name
@@ -7054,6 +7253,17 @@ spec:
                                                       expression pattern that must match
                                                       the header value.
                                                     type: string
+                                                  treatMissingAsEmpty:
+                                                    description: TreatMissingAsEmpty
+                                                      specifies if the header match
+                                                      rule specified header does not
+                                                      exist, this header value will
+                                                      be treated as empty. Defaults
+                                                      to false. Unlike the underlying
+                                                      Envoy implementation this is **only**
+                                                      supported for negative matches
+                                                      (e.g. NotContains, NotExact).
+                                                    type: boolean
                                                 required:
                                                   - name
                                                 type: object
@@ -7236,6 +7446,11 @@ spec:
                             should allow a default certificate to be applied which handles
                             all requests which don't match the SNI defined in this vhost.
                           type: boolean
+                        maximumProtocolVersion:
+                          description: MaximumProtocolVersion is the maximum TLS version
+                            this vhost should negotiate. Valid options are `1.2` and
+                            `1.3` (default). Any other value defaults to TLS 1.3.
+                          type: string
                         minimumProtocolVersion:
                           description: MinimumProtocolVersion is the minimum TLS version
                             this vhost should negotiate. Valid options are `1.2` (default)
@@ -7557,7 +7772,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: tlscertificatedelegations.projectcontour.io
 spec:
   preserveUnknownFields: false


### PR DESCRIPTION
The MR sets `httpVersions` for routes with `router: inter-dc` label no matter what certificate they use.