### PR TITLE
refactor: add wildcard certificate check and fix service port issue

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
@@ -25,12 +31,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
 - apiGroups:
   - projectcontour.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -26,6 +26,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+- apiGroups:
   - projectcontour.io
   resources:
   - httpproxies

--- a/deploy/charts/route-to-contour-httpproxy/templates/manager-rbac.yaml
+++ b/deploy/charts/route-to-contour-httpproxy/templates/manager-rbac.yaml
@@ -26,6 +26,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+- apiGroups:
   - projectcontour.io
   resources:
   - httpproxies

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -32,6 +32,7 @@ const (
 	RouterName       = "default"
 	RouteTimeout     = "120s"
 
+	FirstEndpointsIP             = "10.10.10.10"
 	FirstServiceName             = "foo"
 	FirstRouteName               = "foo"
 	SecondRouteName              = "bar"
@@ -43,11 +44,61 @@ const (
 
 	RateLimitRequests = 100
 	RouteIPWhiteList  = "1.1.1.1 8.8.8.8"
+
+	WildcardCert = `
+-----BEGIN CERTIFICATE-----
+MIIDYzCCAksCFCg7O6rz+l2xyXChgE4ae0e7R64MMA0GCSqGSIb3DQEBCwUAMG4x
+CzAJBgNVBAYTAklSMQ8wDQYDVQQIDAZUZWhyYW4xDzANBgNVBAcMBlRlaHJhbjEO
+MAwGA1UECgwFU25hcHAxEzARBgNVBAsMClNuYXBwQ2xvdWQxGDAWBgNVBAMMDyou
+c25hcHBjbG91ZC5pbzAeFw0yMzExMjEyMDE1MzZaFw0yNDExMjAyMDE1MzZaMG4x
+CzAJBgNVBAYTAklSMQ8wDQYDVQQIDAZUZWhyYW4xDzANBgNVBAcMBlRlaHJhbjEO
+MAwGA1UECgwFU25hcHAxEzARBgNVBAsMClNuYXBwQ2xvdWQxGDAWBgNVBAMMDyou
+c25hcHBjbG91ZC5pbzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALl0
+aldira6ue+gD1uJxo2sViJWzmwITtERhX0HMXJRz1/zFZ9dWavbjgPYplUiS1v1g
+TymcjDqF2ctChZZAjOs2iGaXixA3lKCbKPzXVAPeqyhTIw0N/rwKbmBGVRhIIwI1
+pf1TMyYJiBYuCDN5pf3KZJ1kJ7SqBJO9Qr8wYtZZ+cccvZtpMK+FAsrNef0FFq7P
+0ZXpG0/BB5Oyj3OW2jyy1OKx+nfuEKugnQ50SOi2jD1XeSjOK1YysrY2Ucy9QHK7
+9p5pQNcy1VyRdqXAlDp2Y3MaoswEIxF6mBrBo6os5JJvXHvGFL5XYOAFTOC+lxW9
+SyqpP9DNDnGiQDv5z9ECAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAgjsJTMRGauy7
+1BudiattL9C31V5/6tMWf8qATJF7cpdXBS6c5xoMgRg1Uv+E8ZKqH5cjqTbG/Rns
+KHUpJngavKMw61yFiyDr6xce2svEfn4+Mr42UpBviVQnfE0cBPd17JHiVMBK2nOG
+i7dFAZ0q0nfU3gh4PCGLzdW49tSz3Bt9SDT+9H3t1FnHOdaCcO6SKufnz4IqEoVG
+D3ByZu9s4D/4Yoh4NeP/sHEhP3KnTIQQ+4dh1xWs2/5Hd8l5xBid5esWdOrwWb7s
+XZyVH1FuumB9pepOLY4TYAskLS2/N47DDFjHRucVxHXkhjASh3RXe7+/YSvCTEwQ
+RMsUplRDZg==
+-----END CERTIFICATE-----`
+	WildcardKey = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC5dGpXYq2urnvo
+A9bicaNrFYiVs5sCE7REYV9BzFyUc9f8xWfXVmr244D2KZVIktb9YE8pnIw6hdnL
+QoWWQIzrNohml4sQN5Sgmyj811QD3qsoUyMNDf68Cm5gRlUYSCMCNaX9UzMmCYgW
+LggzeaX9ymSdZCe0qgSTvUK/MGLWWfnHHL2baTCvhQLKzXn9BRauz9GV6RtPwQeT
+so9zlto8stTisfp37hCroJ0OdEjotow9V3kozitWMrK2NlHMvUByu/aeaUDXMtVc
+kXalwJQ6dmNzGqLMBCMRepgawaOqLOSSb1x7xhS+V2DgBUzgvpcVvUsqqT/QzQ5x
+okA7+c/RAgMBAAECggEAIaRJICYB7LSxPHLp2bUUmHnVB5cHsPZDFr51Kbn5N2LW
+VP+4aRs/lx7JB56eeoZMorUEVz+TPpCGZDVih1GZXpfLYZTvAJecig/rfQZQss0D
+TnLaYmVeBt17jVJk4F1BoIZ74HrlxeonuiJKkY/pOSMsYlLHUyIeZ3CHOah83XYw
+xstfOpJbSblz7ph4AB27wA6VgSz5xpu7hhUym/cSaDpNO+MpuLc/hvV/Qg4cxfBT
+WI64F2vKeeB0adxlN0RC8oX+q1jWHUCGicgwm7Vns3RWgljFQk52QEY4UzwvQD90
+z8/RRuWzXoA5lj9Zk6m2Fzm1xatWxSPDAf3/j+lNcwKBgQDm0BtLRGkn9rgdbYiF
+lLKuk0F5pfIeEQrETb4jHQURZ9rRQ3+vFEjdKJQkDKLPvdhtUSNAEkyYuzu+Euo8
+JpAJn9VOQNgCCe/AynMDKioDzVxS5ZNV8Zf5icsG/697PikmP+xTX+upQ/s+5Ey7
+s0WwvX07XNjEwaFTguv4J2aUtwKBgQDNsTOvACzx7VCwFvF/+Xk+vFa+LuWJllIL
+HjtL2fvnZwTWNu8TWeQuZKzhlT/jvDdRG9sllh2d5V/3w6I89HN5G7pvRebqtkAl
+Q2jO7/cW8s1Mf3YPeHZV5QBhLF9xDjttdWSpKXv9dZwYip45iU5a5UxjwSv/v6Wx
+OegWUY+HtwKBgQC/mbN+mKx+O0V9UEbLNLPbTWxF0maZZOY+LJcQyO9DEqZHnrOo
+n7sYs629+ytQLjUyEe+kKUyiYJLoZwVAp3ZcNu04B4YIszzuGmC9GMxF2byxJ9hV
+uLbCtArwpWGDegdotBm24GJdYYx4GcZE7j2EyNfjZmCffGkyTPUbS4HRIwKBgAPp
+IJBtMm2PE3+lkAXc2l9E+Wk4Pwj0oK6xbnMsu8tUfBUOilEV3m67X0YSrlpIE80o
++GuohPuhhseRIp6CD0f4LP08mP1RZbrPo0h763i2OQ0BR19X7PgJGI7AZzghCyQz
+nSxSK5dQCx20VPnHEIRN47vpykpcfGv4K99wwYfVAoGBAMt7EHyH9OSUeDxMXYCU
+zN9qMOvGvppU7//jgcBe23vFf9s2nv1wjkJCH68Tx/TsMjanCeipcT/weYcZM175
+x1FHKiB/ZOqlE9MDamNJlgX+hNJKzJNe9jLkMl1PvUGIwZyV2BrX4VmADLz7jX1Q
+VrNBygXnThcxgGU9gP1srPrq
+-----END PRIVATE KEY-----`
 )
 
 var (
-	ServiceWeight     int32 = 100
-	FirstServicePorts       = []v12.ServicePort{{Name: "https", Port: 443}}
+	ServiceWeight int32 = 100
 )
 
 var _ = Describe("Testing Route to HTTPProxy Controller", func() {
@@ -65,14 +116,37 @@ var _ = Describe("Testing Route to HTTPProxy Controller", func() {
 					Name:      FirstServiceName,
 				},
 				Spec: v12.ServiceSpec{
-					Ports: FirstServicePorts,
-					Type:  v12.ServiceTypeClusterIP,
+					Ports: []v12.ServicePort{
+						{Name: "https", Port: 443, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 8443}},
+						{Name: "http", Port: 80, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 8080}},
+					},
+					Type: v12.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						"app": "test",
 					},
 				},
 			}
 			Expect(k8sClient.Create(context.Background(), &objService)).To(Succeed())
+
+			objEndpoints := v12.Endpoints{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: DefaultNamespace,
+					Name:      FirstServiceName,
+				},
+				Subsets: []v12.EndpointSubset{
+					{
+						Addresses: []v12.EndpointAddress{
+							{IP: FirstEndpointsIP},
+						},
+						Ports: []v12.EndpointPort{
+							{Name: "https", Port: 8443, Protocol: v12.ProtocolTCP},
+							{Name: "http", Port: 8080, Protocol: v12.ProtocolTCP},
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(context.Background(), &objEndpoints)).To(Succeed())
 		})
 
 		getSampleRoute := func() *routev1.Route {
@@ -87,7 +161,7 @@ var _ = Describe("Testing Route to HTTPProxy Controller", func() {
 				Spec: routev1.RouteSpec{
 					Host: FirstRouteFQDN,
 					Port: &routev1.RoutePort{
-						TargetPort: intstr.IntOrString{IntVal: 443},
+						TargetPort: intstr.IntOrString{IntVal: 8443},
 					},
 					To: routev1.RouteTargetReference{
 						Name:   FirstServiceName,
@@ -165,11 +239,12 @@ var _ = Describe("Testing Route to HTTPProxy Controller", func() {
 			cleanUpRoute(objRoute)
 		})
 
-		It("should create HTTPProxy object when everything is alright", func() {
+		It("should create HTTPProxy object when everything is alright (valid targetPort as integer)", func() {
 			objRoute := getSampleRoute()
 			objRoute.Annotations = map[string]string{
 				consts.AnnotTimeout: RouteTimeout,
 			}
+			objRoute.Spec.Port.TargetPort = intstr.IntOrString{IntVal: 8443}
 			Expect(k8sClient.Create(context.Background(), objRoute)).To(Succeed())
 
 			admitRoute(objRoute)
@@ -183,6 +258,84 @@ var _ = Describe("Testing Route to HTTPProxy Controller", func() {
 				g.Expect(len(httpProxyList.Items)).To(Equal(1))
 				g.Expect(httpProxyList.Items[0].Spec.VirtualHost.Fqdn).To(Equal(FirstRouteFQDN))
 				g.Expect(httpProxyList.Items[0].Spec.Routes[0].TimeoutPolicy.Response).To(Equal(RouteTimeout))
+				g.Expect(len(httpProxyList.Items[0].Spec.Routes[0].Services)).To(Equal(1))
+				g.Expect(httpProxyList.Items[0].Spec.Routes[0].Services[0].Port).To(Equal(443))
+			}).Should(Succeed())
+
+			cleanUpRoute(objRoute)
+		})
+
+		It("should create HTTPProxy object when everything is alright (valid targetPort as string)", func() {
+			objRoute := getSampleRoute()
+			objRoute.Annotations = map[string]string{
+				consts.AnnotTimeout: RouteTimeout,
+			}
+			objRoute.Spec.Port.TargetPort = intstr.IntOrString{Type: intstr.String, StrVal: "https"}
+			Expect(k8sClient.Create(context.Background(), objRoute)).To(Succeed())
+
+			admitRoute(objRoute)
+
+			rObj := routev1.Route{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Namespace: DefaultNamespace, Name: FirstRouteName}, &rObj)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				httpProxyList := contourv1.HTTPProxyList{}
+				g.Expect(k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))).To(Succeed())
+				g.Expect(len(httpProxyList.Items)).To(Equal(1))
+				g.Expect(httpProxyList.Items[0].Spec.VirtualHost.Fqdn).To(Equal(FirstRouteFQDN))
+				g.Expect(httpProxyList.Items[0].Spec.Routes[0].TimeoutPolicy.Response).To(Equal(RouteTimeout))
+				g.Expect(len(httpProxyList.Items[0].Spec.Routes[0].Services)).To(Equal(1))
+				g.Expect(httpProxyList.Items[0].Spec.Routes[0].Services[0].Port).To(Equal(443))
+			}).Should(Succeed())
+
+			cleanUpRoute(objRoute)
+		})
+
+		It("should create HTTPProxy object when everything is alright (invalid targetPort as integer)", func() {
+			objRoute := getSampleRoute()
+			objRoute.Annotations = map[string]string{
+				consts.AnnotTimeout: RouteTimeout,
+			}
+			objRoute.Spec.Port.TargetPort = intstr.IntOrString{IntVal: 443}
+			Expect(k8sClient.Create(context.Background(), objRoute)).To(Succeed())
+
+			admitRoute(objRoute)
+
+			rObj := routev1.Route{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Namespace: DefaultNamespace, Name: FirstRouteName}, &rObj)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				httpProxyList := contourv1.HTTPProxyList{}
+				g.Expect(k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))).To(Succeed())
+				g.Expect(len(httpProxyList.Items)).To(Equal(1))
+				g.Expect(httpProxyList.Items[0].Spec.VirtualHost.Fqdn).To(Equal(FirstRouteFQDN))
+				g.Expect(httpProxyList.Items[0].Spec.Routes[0].TimeoutPolicy.Response).To(Equal(RouteTimeout))
+				g.Expect(len(httpProxyList.Items[0].Spec.Routes)).To(Equal(2))
+			}).Should(Succeed())
+
+			cleanUpRoute(objRoute)
+		})
+
+		It("should create HTTPProxy object when everything is alright (invalid targetPort as string)", func() {
+			objRoute := getSampleRoute()
+			objRoute.Annotations = map[string]string{
+				consts.AnnotTimeout: RouteTimeout,
+			}
+			objRoute.Spec.Port.TargetPort = intstr.IntOrString{Type: intstr.String, StrVal: "notValid"}
+			Expect(k8sClient.Create(context.Background(), objRoute)).To(Succeed())
+
+			admitRoute(objRoute)
+
+			rObj := routev1.Route{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Namespace: DefaultNamespace, Name: FirstRouteName}, &rObj)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				httpProxyList := contourv1.HTTPProxyList{}
+				g.Expect(k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))).To(Succeed())
+				g.Expect(len(httpProxyList.Items)).To(Equal(1))
+				g.Expect(httpProxyList.Items[0].Spec.VirtualHost.Fqdn).To(Equal(FirstRouteFQDN))
+				g.Expect(httpProxyList.Items[0].Spec.Routes[0].TimeoutPolicy.Response).To(Equal(RouteTimeout))
+				g.Expect(len(httpProxyList.Items[0].Spec.Routes)).To(Equal(2))
 			}).Should(Succeed())
 
 			cleanUpRoute(objRoute)
@@ -465,12 +618,58 @@ var _ = Describe("Testing Route to HTTPProxy Controller", func() {
 			cleanUpRoute(route)
 		})
 
+		It("Should set http versions to [http/1.1] for non-inter-dc routes that use a custom wildcard certificate", func() {
+			route := getSampleRoute()
+			route.Spec.TLS = &routev1.TLSConfig{
+				Termination: routev1.TLSTerminationEdge,
+			}
+			route.Spec.TLS.Key = WildcardKey
+			route.Spec.TLS.Certificate = WildcardCert
+			Expect(k8sClient.Create(context.Background(), route)).To(Succeed())
+
+			admitRoute(route)
+
+			Eventually(func(g Gomega) {
+				httpProxyList := contourv1.HTTPProxyList{}
+				g.Expect(k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))).To(Succeed())
+				g.Expect(len(httpProxyList.Items)).To(Equal(1))
+				g.Expect(len(httpProxyList.Items[0].Spec.HttpVersions)).To(Equal(1))
+				g.Expect(httpProxyList.Items[0].Spec.HttpVersions[0]).To(Equal(contourv1.HttpVersion("http/1.1")))
+			}).Should(Succeed())
+
+			cleanUpRoute(route)
+		})
+
 		It("Should set http versions to [h2, http/1.1] for inter-dc routes that use the default certificate", func() {
 			route := getSampleRoute()
 			route.Spec.TLS = &routev1.TLSConfig{
 				Termination: routev1.TLSTerminationEdge,
 			}
 			route.Labels[consts.RouteShardLabel] = consts.IngressClassInterDc
+			Expect(k8sClient.Create(context.Background(), route)).To(Succeed())
+
+			admitRoute(route)
+
+			Eventually(func(g Gomega) {
+				httpProxyList := contourv1.HTTPProxyList{}
+				g.Expect(k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))).To(Succeed())
+				g.Expect(len(httpProxyList.Items)).To(Equal(1))
+				g.Expect(len(httpProxyList.Items[0].Spec.HttpVersions)).To(Equal(2))
+				g.Expect(httpProxyList.Items[0].Spec.HttpVersions[0]).To(Equal(contourv1.HttpVersion("h2")))
+				g.Expect(httpProxyList.Items[0].Spec.HttpVersions[1]).To(Equal(contourv1.HttpVersion("http/1.1")))
+			}).Should(Succeed())
+
+			cleanUpRoute(route)
+		})
+
+		It("Should set http versions to [h2, http/1.1] for inter-dc routes that use a custom wildcard certificate", func() {
+			route := getSampleRoute()
+			route.Spec.TLS = &routev1.TLSConfig{
+				Termination: routev1.TLSTerminationEdge,
+			}
+			route.Labels[consts.RouteShardLabel] = consts.IngressClassInterDc
+			route.Spec.TLS.Key = WildcardKey
+			route.Spec.TLS.Certificate = WildcardCert
 			Expect(k8sClient.Create(context.Background(), route)).To(Succeed())
 
 			admitRoute(route)

--- a/pkg/utils/cert.go
+++ b/pkg/utils/cert.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+)
+
+func IsWildcardCertificate(cert string) (bool, error) {
+	// Decode the first PEM block (end-entity certificate)
+	block, _ := pem.Decode([]byte(cert))
+	if block == nil {
+		return false, nil
+	}
+
+	// Parse the end-entity certificate
+	certificate, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false, err
+	}
+
+	// Check for wildcard in Common Name (CN)
+	if strings.HasPrefix(certificate.Subject.CommonName, "*.") {
+		return true, nil
+	}
+
+	// Check for wildcards in Subject Alternative Names (SAN)
+	for _, dnsName := range certificate.DNSNames {
+		if strings.HasPrefix(dnsName, "*.") {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
This commit involves two changes:

1. Wildcard Certificate Check: The update introduces a mechanism to inspect each custom certificate. If a certificate is identified as a wildcard certificate, the system is configured to utilize HTTP/1.1. Conversely, if the certificate is not a wildcard, both HTTP/1.1 and HTTP/2 (h2) protocols are enabled in the Contour HTTPProxy object.
2. Service Port Issue Fix: The commit also addresses a bug related to Route targetPort. Previously, targetPort was checked against a list of service ports. This update corrects the issue by ensuring that the targetPort is now checked against the endpoints port list, which is the appropriate reference for this operation.