### PR TITLE
fix: route admission status check

### DIFF
--- a/deploy/charts/route-to-contour-httpproxy/Chart.yaml
+++ b/deploy/charts/route-to-contour-httpproxy/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.4
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.5"
+appVersion: "1.3.6"

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Testing Route to HTTPProxy Controller", func() {
 			route.Status = routev1.RouteStatus{
 				Ingress: []routev1.RouteIngress{
 					{
-						RouterName: route.Labels[consts.RouteShardLabel],
+						RouterName: "default",
 						Conditions: []routev1.RouteIngressCondition{
 							{
 								Status: v12.ConditionStatus(v1.ConditionTrue),

--- a/pkg/utils/route.go
+++ b/pkg/utils/route.go
@@ -19,19 +19,10 @@ func IsAdmitted(route *routev1.Route) (admitted, hasAdmissionStatus bool) {
 	if len(route.Status.Ingress) < 1 || len(route.Status.Ingress[0].Conditions) < 1 {
 		return false, false
 	}
-	var routerName string
-	// the default ingress controller selects any routes not selected by the other ingress controllers
-	switch route.ObjectMeta.Labels[consts.LabelKeyRouterName] {
-	case consts.IngressClassPublic:
-		routerName = consts.IngressClassPublic
-	case consts.IngressClassInterDc:
-		routerName = consts.IngressClassInterDc
-	default:
-		routerName = "default"
-	}
 
+	// the default ingress controller selects all routes
 	for _, ingress := range route.Status.Ingress {
-		if ingress.RouterName == routerName {
+		if ingress.RouterName == "default" {
 			for _, condition := range ingress.Conditions {
 				if condition.Type == routev1.RouteAdmitted {
 					return condition.Status == v1.ConditionTrue, true


### PR DESCRIPTION
This update revises the `IsAdmitted` function, removing specific admission status checks based on the `routerName` as there are no more specific routers and it's only the default router that does the admission.