### PR TITLE
refactor: enhance HttpVersion translation

### DIFF
--- a/deploy/charts/route-to-contour-httpproxy/Chart.yaml
+++ b/deploy/charts/route-to-contour-httpproxy/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.6"
+appVersion: "1.3.7"

--- a/internal/controller/route/handler.go
+++ b/internal/controller/route/handler.go
@@ -292,7 +292,7 @@ func (r *Reconciler) assembleHttpproxy(ctx context.Context, owner *routev1.Route
 	httpproxy.Spec.IngressClassName = utils.GetIngressClass(owner)
 
 	// Enable h2 and http/1.1 by default.
-	// Later we disable h2 for a specific set of routes
+	// Later we disable h2 for a specific set of routes.
 	httpproxy.Spec.HttpVersions = []contourv1.HttpVersion{"h2", "http/1.1"}
 
 	if owner.Spec.TLS != nil {
@@ -342,6 +342,12 @@ func (r *Reconciler) assembleHttpproxy(ctx context.Context, owner *routev1.Route
 		default:
 			return nil, fmt.Errorf("invalid termination mode specified on route")
 		}
+	} else {
+		httpproxy.Spec.HttpVersions = []contourv1.HttpVersion{"http/1.1"}
+	}
+
+	if utils.IsHttp1Enforced(r.route) {
+		httpproxy.Spec.HttpVersions = []contourv1.HttpVersion{"http/1.1"}
 	}
 
 	// use `tcpproxy` for passthrough mode and `routes` for other termination modes

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -18,6 +18,7 @@ const (
 
 	AnnotationKeyPrefix               = "snappcloud.io/"
 	AnnotationKeyReconciliationPaused = AnnotationKeyPrefix + "paused"
+	AnnotationKeyHttp1Enforced        = AnnotationKeyPrefix + "force-h1"
 
 	TLSSecretNS         = "openshift-ingress"
 	TLSSecretName       = "letsencrypt"

--- a/pkg/utils/meta.go
+++ b/pkg/utils/meta.go
@@ -20,6 +20,16 @@ func IsDeleted(obj metav1.Object) bool {
 	return !obj.GetDeletionTimestamp().IsZero()
 }
 
+// IsHttp1Enforced returns true if the object has the AnnotationKeyHttp1Enforced
+func IsHttp1Enforced(obj metav1.Object) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, ok := annotations[consts.AnnotationKeyHttp1Enforced]
+	return ok
+}
+
 // IsPaused returns true if the object has the AnnotationKeyReconciliationPaused
 func IsPaused(obj metav1.Object) bool {
 	annotations := obj.GetAnnotations()


### PR DESCRIPTION
This PR introduces two new changes:

- In the absence of a TLS specification within a route object, the controller now defaults to HTTP/1.1 as the only supported HTTP version.
-  A new annotation key, `snappcloud.io/force-h1`, has been introduced. When this annotation is present on a route object, the controller will enforce the use of HTTP/1.1 irrespective of the annotation's value. This feature provides administrators with a method to apply HTTP version policies.
**Important Note**: To achieve consistent behavior, for all routes that comprise an HTTPProxy object, it is essential to annotate each route accordingly. If any corresponding route does not include this annotation, the supported HTTP versions may vary, analogous to the existing pause mechanism.