### PR TITLE
feat: add support to force http/1.1 into httpproxy using config

### DIFF
--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -1,5 +1,7 @@
 routeToContourRatio: 1
 commonHostSuffix: .okd4.ts-1.staging-snappcloud.io
+forceH1ForIngressClass:
+- private
 defaultTimeout:
   publicClass: 5s
   interDcClass: 5s

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	// CommonHostSuffix will be removed from its end if present
 	CommonHostSuffix string `koanf:"commonHostSuffix"`
 
+	// All httpproxy objects with these ingressClass names will only have http/1.1 set in their httpVersions field.
+	ForceH1ForIngressClass []string `koanf:"forceH1ForIngressClass"`
+
 	DefaultTimeout DefaultTimeout `koanf:"defaultTimeout"`
 }
 

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -705,13 +705,34 @@ var _ = Describe("Testing Route to HTTPProxy Controller", func() {
 			cleanUpRoute(route)
 		})
 
-		It("Should set http versions to [http/1.1] for routes that enforce http/1.1", func() {
+		It("Should set http versions to [http/1.1] for routes that enforce http/1.1 using annotation", func() {
 			route := getSampleRoute()
 			route.Annotations = map[string]string{
 				consts.AnnotationKeyHttp1Enforced: "",
 			}
 			// Routes labeled as 'inter-dc' will use h2 in addition to http/1.1, independent of the certificate wildcard status.
 			route.Labels[consts.RouteShardLabel] = consts.IngressClassInterDc
+			route.Spec.TLS = &routev1.TLSConfig{
+				Termination: routev1.TLSTerminationEdge,
+			}
+			Expect(k8sClient.Create(context.Background(), route)).To(Succeed())
+
+			admitRoute(route)
+
+			Eventually(func(g Gomega) {
+				httpProxyList := contourv1.HTTPProxyList{}
+				g.Expect(k8sClient.List(context.Background(), &httpProxyList, client.InNamespace(DefaultNamespace))).To(Succeed())
+				g.Expect(len(httpProxyList.Items)).To(Equal(1))
+				g.Expect(len(httpProxyList.Items[0].Spec.HttpVersions)).To(Equal(1))
+				g.Expect(httpProxyList.Items[0].Spec.HttpVersions[0]).To(Equal(contourv1.HttpVersion("http/1.1")))
+			}).Should(Succeed())
+
+			cleanUpRoute(route)
+		})
+
+		It("Should set http versions to [http/1.1] for routes that enforce http/1.1 using config", func() {
+			route := getSampleRoute()
+			route.Labels[consts.RouteShardLabel] = consts.IngressClassPrivate
 			route.Spec.TLS = &routev1.TLSConfig{
 				Termination: routev1.TLSTerminationEdge,
 			}

--- a/internal/controller/route/handler.go
+++ b/internal/controller/route/handler.go
@@ -346,7 +346,7 @@ func (r *Reconciler) assembleHttpproxy(ctx context.Context, owner *routev1.Route
 		httpproxy.Spec.HttpVersions = []contourv1.HttpVersion{"http/1.1"}
 	}
 
-	if utils.IsHttp1Enforced(r.route) {
+	if utils.IsHttp1Enforced(r.route, r.cfg.ForceH1ForIngressClass) {
 		httpproxy.Spec.HttpVersions = []contourv1.HttpVersion{"http/1.1"}
 	}
 

--- a/pkg/utils/meta.go
+++ b/pkg/utils/meta.go
@@ -20,16 +20,6 @@ func IsDeleted(obj metav1.Object) bool {
 	return !obj.GetDeletionTimestamp().IsZero()
 }
 
-// IsHttp1Enforced returns true if the object has the AnnotationKeyHttp1Enforced
-func IsHttp1Enforced(obj metav1.Object) bool {
-	annotations := obj.GetAnnotations()
-	if annotations == nil {
-		return false
-	}
-	_, ok := annotations[consts.AnnotationKeyHttp1Enforced]
-	return ok
-}
-
 // IsPaused returns true if the object has the AnnotationKeyReconciliationPaused
 func IsPaused(obj metav1.Object) bool {
 	annotations := obj.GetAnnotations()

--- a/pkg/utils/route.go
+++ b/pkg/utils/route.go
@@ -34,6 +34,28 @@ func IsAdmitted(route *routev1.Route) (admitted, hasAdmissionStatus bool) {
 	return false, false
 }
 
+// IsHttp1Enforced returns true if http/1.1 should be forced into corresponding httpproxy object of the route object
+func IsHttp1Enforced(route *routev1.Route, forcedIngressClasses []string) bool {
+	if forcedIngressClasses != nil {
+		routeIngressClass := GetIngressClass(route)
+
+		for _, forcedIngressClass := range forcedIngressClasses {
+			if routeIngressClass == forcedIngressClass {
+				return true
+			}
+		}
+	}
+
+	annotations := route.GetAnnotations()
+	if annotations != nil {
+		if _, ok := annotations[consts.AnnotationKeyHttp1Enforced]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
 func GetIngressClass(route *routev1.Route) string {
 	ingressClass := route.Labels[consts.RouteShardLabel]
 


### PR DESCRIPTION
This PR adds support to force `http/1.1` as the only HTTP version supported, in all the `httpproxy` objects with a specific `ingressClassName` defined through the config file.