### PR TITLE
add endpoints list/watch access to the manager c-role

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,6 +11,8 @@ rules:
   - endpoints
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/route/handler.go
+++ b/internal/controller/route/handler.go
@@ -71,7 +71,7 @@ func NewReconciler(mgr manager.Manager, cfg *config.Config) *Reconciler {
 // +kubebuilder:rbac:groups=projectcontour.io,resources=httpproxies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get
+// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.logger = log.FromContext(ctx)


### PR DESCRIPTION
The PR adds list & watch accesses on `endpoints` to the manager cluster-role.
This is done to prevent [this issue](https://github.com/kubernetes/client-go/issues/829).